### PR TITLE
JNG-4686 relation actions

### DIFF
--- a/judo-ui-react/src/main/resources/actor/src/components/PageHeader.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/PageHeader.tsx.hbs
@@ -23,7 +23,7 @@ export const PageHeader = ({ title, children }: PageHeaderProps) => {
 
   return (
     <>
-      <AppBar component="div" position="static" elevation={0} sx={ { zIndex: 0 } }>
+      <AppBar component="div" position="sticky" elevation={0}>
         <Toolbar>
           <Container component="main" maxWidth="xl">
             <Grid container alignItems="center" justifyContent="space-between" spacing={1}>
@@ -40,8 +40,8 @@ export const PageHeader = ({ title, children }: PageHeaderProps) => {
             </Grid>
           </Container>
         </Toolbar>
+        <Divider />
       </AppBar>
-      <Divider />
     </>
   );
 };

--- a/judo-ui-react/src/main/resources/actor/src/components/widgets/AggregationInput.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/widgets/AggregationInput.tsx.hbs
@@ -18,7 +18,7 @@ interface AggregationInputProps {
   error?: boolean | undefined;
   helperText?: string | undefined;
   disabled?: boolean | undefined;
-  readonly?: boolean | undefined;
+  editMode?: boolean | undefined;
   labelList: string[];
   icon?: ReactNode;
   onCreate?: () => Promise<void> | undefined;
@@ -30,23 +30,6 @@ interface AggregationInputProps {
   onView?: () => Promise<void> | undefined;
 }
 
-interface ViewIconsProps {
-  value: any | undefined | null;
-  disabled: boolean;
-  onView?: () => Promise<void> | undefined;
-  onEdit?: () => Promise<void> | undefined;
-  onCreate?: () => Promise<void> | undefined;
-  onDelete?: () => Promise<void> | undefined;
-}
-
-interface EditIconsProps {
-  value: any | undefined | null;
-  disabled: boolean;
-  onRemove?: () => Promise<void> | undefined;
-  onSet?: () => Promise<void> | undefined;
-  onUnset?: () => Promise<void> | undefined;
-}
-
 export const AggregationInput = ({
   name,
   id,
@@ -55,7 +38,7 @@ export const AggregationInput = ({
   error = false,
   helperText,
   disabled = false,
-  readonly = true,
+  editMode = true,
   labelList,
   icon,
   onCreate,
@@ -68,19 +51,11 @@ export const AggregationInput = ({
 }: AggregationInputProps) => {
   const [focused, setFocused] = useState(false);
 
-  let icons: ReactNode;
-
-  if (readonly) {
-    icons = <ViewIcons value={value} disabled={disabled} onCreate={onCreate} onView={onView} onDelete={onDelete} onEdit={onEdit} />;
-  } else {
-    icons = <EditIcons value={value} disabled={disabled} onRemove={onRemove} onSet={onSet} onUnset={onUnset} />;
-  }
-
   return (
     <Grid container item direction="row" justifyContent="stretch" alignContent="stretch">
       <ButtonBase
         sx={ { padding: 0, flexGrow: 1 } }
-        disabled={disabled || readonly}
+        disabled={disabled || !onSet}
         onFocusCapture={() => setFocused(true)}
         onBlur={() => setFocused(false)}
         onClick={onSet}
@@ -94,7 +69,7 @@ export const AggregationInput = ({
           focused={focused}
           fullWidth
           value={labelList.filter(l => !!l && l.length > 0).join(' - ')}
-          className={!onSet || disabled || readonly ? 'Mui-readOnly' : undefined}
+          className={!onSet || disabled || !editMode ? 'Mui-readOnly' : undefined}
           sx={ {
             ':hover': {
               cursor: 'pointer',
@@ -104,81 +79,46 @@ export const AggregationInput = ({
             },
           } }
           InputProps={ {
-            readOnly: true,
+            readOnly: !onSet || disabled,
             startAdornment: <InputAdornment position="start">{icon}</InputAdornment>,
           } }
         />
       </ButtonBase>
-      {icons}
-    </Grid>
-  );
-};
-
-const ViewIcons = ({ value, disabled, onCreate, onDelete, onView, onEdit }: ViewIconsProps) => {
-  let icons: ReactNode;
-
-  if (exists(value)) {
-    icons = (
-      <>
-        {onView && (
-          <IconButton disabled={disabled} onClick={onView}>
-            <MdiIcon path="eye" />
-          </IconButton>
-        )}
-        {onEdit && (
-          <IconButton disabled={disabled} onClick={onEdit}>
-            <MdiIcon path="pencil" />
-          </IconButton>
-        )}
-        {onDelete && (
-          <IconButton disabled={disabled} onClick={onDelete}>
-            <MdiIcon path="delete" />
-          </IconButton>
-        )}
-      </>
-    );
-  } else {
-    icons = (
-      <>
-        {onCreate && (
-          <IconButton disabled={disabled} onClick={onCreate}>
-            <MdiIcon path="file_document_plus" />
-          </IconButton>
-        )}
-      </>
-    );
-  }
-
-  return <>{icons}</>;
-};
-
-const EditIcons = ({ value, disabled, onRemove, onSet, onUnset }: EditIconsProps) => {
-  let icons: ReactNode;
-
-  if (exists(value)) {
-    icons = (
-      <>
-        {onRemove && (
-          <IconButton disabled={disabled} onClick={onRemove}>
-            <MdiIcon path="link_off" />
-          </IconButton>
-        )}
-        {onUnset && (
-          <IconButton disabled={disabled} onClick={onUnset}>
-            <MdiIcon path="link_off" />
-          </IconButton>
-        )}
-      </>
-    );
-  } else {
-    icons = <>
-      {onSet && (
-        <IconButton disabled={disabled} onClick={onSet}>
-          <MdiIcon path="link" />
+      {exists(value) && onView && (
+        <IconButton disabled={disabled || editMode} onClick={onView}>
+          <MdiIcon path="eye" />
         </IconButton>
       )}
-    </>;
-  }
-
-  return <>{icons}</>;
+      {exists(value) && onEdit && (
+        <IconButton disabled={disabled || editMode} onClick={onEdit}>
+          <MdiIcon path="pencil" />
+        </IconButton>
+      )}
+      {exists(value) && onDelete && (
+        <IconButton disabled={disabled || editMode} onClick={onDelete}>
+          <MdiIcon path="delete" />
+        </IconButton>
+      )}
+      {exists(value) && onRemove && (
+        <IconButton disabled={disabled} onClick={onRemove}>
+            <MdiIcon path="link_off" />
+        </IconButton>
+      )}
+      {exists(value) && onUnset && (
+        <IconButton disabled={disabled} onClick={onUnset}>
+            <MdiIcon path="link_off" />
+        </IconButton>
+      )}
+      {!exists(value) && onCreate && (
+        <IconButton disabled={disabled || editMode} onClick={onCreate}>
+          <MdiIcon path="file_document_plus" />
+        </IconButton>
+      )}
+      {/*onSet && (
+        <IconButton disabled={disabled} onClick={onSet}>
+            <MdiIcon path="link" />
+        </IconButton>
+      )*/}
+    </Grid>
+  );
 };

--- a/judo-ui-react/src/main/resources/actor/src/components/widgets/AssociationButton.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/widgets/AssociationButton.tsx.hbs
@@ -38,7 +38,7 @@ export function AssociationButton<T> ({ id, editMode, fetchCall, navigateAction,
     }, []);
 
     return (
-        <Button id={id} variant="outlined" onClick={() => navigateAction(data!)} disabled={isLoading || editMode || !(data?.__signedIdentifier)}>
+        <Button id={id} variant="text" onClick={() => navigateAction(data!)} disabled={isLoading || editMode || !(data?.__signedIdentifier)}>
             {children}
         </Button>
     );
@@ -53,7 +53,7 @@ export function CollectionAssociationButton<O> ({ id, editMode, isLoading, navig
     const { navigate } = useJudoNavigation();
 
     return (
-        <Button id={id} variant="outlined" onClick={() => navigateAction()} disabled={isLoading || editMode}>
+        <Button id={id} variant="text" onClick={() => navigateAction()} disabled={isLoading || editMode}>
             {children}
         </Button>
     );

--- a/judo-ui-react/src/main/resources/actor/src/fragments/page/page-crud-actions.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/fragments/page/page-crud-actions.hbs
@@ -1,0 +1,54 @@
+{{# if page.dataElement.isUpdatable }}
+    {editMode && (
+        <Grid item>
+            <Button id="page-action-edit-save" onClick={() => saveData()} disabled={isLoading}>
+                <MdiIcon path="content-save" />
+                {t('judo.pages.save', { defaultValue: 'Save' })}
+            </Button>
+        </Grid>
+    )}
+    {editMode && (
+        <Grid item>
+            <Button
+                id="page-action-edit-cancel"
+                variant="outlined"
+                onClick={() => {
+                    setEditMode(false);
+                    fetchData();
+                }}
+                disabled={isLoading}
+            >
+                <MdiIcon path="cancel" />
+                {t('judo.pages.cancel', { defaultValue: 'Cancel' })}
+            </Button>
+        </Grid>
+    )}
+    {!editMode && (
+        <Grid item>
+            <Button id="page-action-edit" onClick={() => setEditMode(true)} disabled={isLoading || !data.__updateable}>
+                <MdiIcon path="pencil" />
+                {t('judo.pages.edit', { defaultValue: 'Edit' })}
+            </Button>
+        </Grid>
+    )}
+{{/ if }}
+{{# if page.dataElement.isRefreshable }}
+    {!editMode && (
+        <Grid item>
+            <Button id="page-action-refresh" onClick={() => fetchData()} disabled={isLoading}>
+                <MdiIcon path="refresh" />
+                {t('judo.pages.refresh', { defaultValue: 'Refresh' })}
+            </Button>
+        </Grid>
+    )}
+{{/ if }}
+{{# if page.dataElement.isDeletable }}
+    {!editMode && (
+        <Grid item>
+            <Button id="page-action-delete" onClick={() => deleteData()} disabled={isLoading || !data.__deleteable}>
+                <MdiIcon path="delete" />
+                {t('judo.pages.delete', { defaultValue: 'Delete' })}
+            </Button>
+        </Grid>
+    )}
+{{/ if }}

--- a/judo-ui-react/src/main/resources/actor/src/layout/Header.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/layout/Header.tsx.hbs
@@ -22,7 +22,7 @@ export function Header(props: HeaderProps) {
         <Toolbar>
           <Grid item>
             <Button variant="text" color="secondary" onClick={ () => back() } disabled={isBackDisabled}>
-              <MdiIcon path="arrow_back" />
+              <MdiIcon path="arrow-left" />
             </Button>
           </Grid>
           <Grid container direction="row">

--- a/judo-ui-react/src/main/resources/actor/src/pages/access/view.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/access/view.hbs
@@ -134,23 +134,8 @@ export default function {{ pageName page }}() {
                     label: t('judo.pages.table.remove', { defaultValue: 'Remove' }) as string,
                     icon: <MdiIcon path="link_off" />,
                     action: async (row: {{ classDataName table.dataElement.target 'Stored' }}) => {
-                        if (editMode) {
-                            storeDiff('{{ table.dataElement.name }}', [...(data.{{ table.dataElement.name }} || []).filter((e: {{ classDataName table.dataElement.target 'Stored' }}) => e.__signedIdentifier !== row.__signedIdentifier)]);
-                        } else {
-                            try {
-                                await {{ classServiceName table.dataElement.owner }}Impl.remove{{ firstToUpper table.dataElement.name }}(
-                                    { __signedIdentifier: data.__signedIdentifier } as JudoIdentifiable<{{ classDataName table.dataElement.owner '' }}>,
-                                    [row],
-                                );
-
-                                fetchData();
-                            } catch (error) {
-                                enqueueSnackbar(t('judo.component.Table.error.remove', { defaultValue: 'Could not remove element!' }) as string, {
-                                    variant: 'error',
-                                });
-                                console.error(error);
-                            }
-                        }
+                        setEditMode(true);
+                        storeDiff('{{ table.dataElement.name }}', [...(data.{{ table.dataElement.name }} || []).filter((e: {{ classDataName table.dataElement.target 'Stored' }}) => e.__signedIdentifier !== row.__signedIdentifier)]);
                     },
                 },
             {{/ if }}
@@ -161,7 +146,7 @@ export default function {{ pageName page }}() {
                         label: t('judo.pages.table.delete', { defaultValue: 'Delete' }) as string,
                         icon: <MdiIcon path="{{ action.icon.name }}" />,
                         action: async (row: {{ classDataName table.dataElement.target 'Stored' }}) => {{ actionFunctionName action page }}({{# if (hasDataElementOwner action.dataElement) }}data, {{/ if }}row, () => fetchData()),
-                        disabled: (row: {{ classDataName table.dataElement.target 'Stored' }}) => !row.__deleteable,
+                        disabled: (row: {{ classDataName table.dataElement.target 'Stored' }}) => editMode || !row.__deleteable,
                     },
                 {{/ if }}
                 {{# if action.isCallOperationAction }}
@@ -170,6 +155,7 @@ export default function {{ pageName page }}() {
                         label: t('{{ idToTranslationKey action.fQName application }}', { defaultValue: '{{ action.label }}' }) as string,
                         icon: <MdiIcon path="{{ action.icon.name }}" />,
                         action: async (row: {{ classDataName table.dataElement.target 'Stored' }}) => {{ actionFunctionName action page }}({{# if action.operation.isMapped }}row, {{/ if }}() => fetchData()),
+                        disabled: (row: {{ classDataName table.dataElement.target 'Stored' }}) => editMode,
                     },
                 {{/ if }}
             {{/ each }}
@@ -295,60 +281,7 @@ export default function {{ pageName page }}() {
         <>
             {{# with (getDataContainerForPage page) as |rootChild| }}
                 <PageHeader title={title}>
-                    {{# if page.relationType.isRefreshable }}
-                        {!editMode && (
-                            <Grid item>
-                                <Button id="page-action-refresh" onClick={() => fetchData()} disabled={isLoading}>
-                                    <MdiIcon path="refresh" />
-                                    {t('judo.pages.refresh', { defaultValue: 'Refresh' })}
-                                </Button>
-                            </Grid>
-                        )}
-                    {{/ if }}
-                    {{# if page.relationType.isDeletable }}
-                        {!editMode && (
-                            <Grid item>
-                                <Button id="page-action-delete" onClick={() => deleteData()} disabled={isLoading || !data.__deleteable}>
-                                    <MdiIcon path="delete" />
-                                    {t('judo.pages.delete', { defaultValue: 'Delete' })}
-                                </Button>
-                            </Grid>
-                        )}
-                    {{/ if }}
-                    {{# if page.relationType.isUpdatable }}
-                        {!editMode && (
-                            <Grid item>
-                                <Button id="page-action-edit" onClick={() => setEditMode(true)} disabled={isLoading || !data.__updateable}>
-                                    <MdiIcon path="pencil" />
-                                    {t('judo.pages.edit', { defaultValue: 'Edit' })}
-                                </Button>
-                            </Grid>
-                        )}
-                        {editMode && (
-                            <Grid item>
-                                <Button
-                                    id="page-action-edit-cancel"
-                                    variant="outlined"
-                                    onClick={() => {
-                                        setEditMode(false);
-                                        fetchData();
-                                    }}
-                                    disabled={isLoading}
-                                >
-                                    <MdiIcon path="cancel" />
-                                    {t('judo.pages.cancel', { defaultValue: 'Cancel' })}
-                                </Button>
-                            </Grid>
-                        )}
-                        {editMode && (
-                            <Grid item>
-                                <Button id="page-action-edit-save" onClick={() => saveData()} disabled={isLoading}>
-                                    <MdiIcon path="content-save" />
-                                    {t('judo.pages.save', { defaultValue: 'Save' })}
-                                </Button>
-                            </Grid>
-                        )}
-                    {{/ if }}
+                    {{> actor/src/fragments/page/page-crud-actions.hbs }}
                 </PageHeader>
                 <Container component="main" maxWidth="xl">
                     <Box sx={mainContainerPadding}>

--- a/judo-ui-react/src/main/resources/actor/src/pages/actions/action/call-operation-action/output-view/output-view.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/actions/action/call-operation-action/output-view/output-view.tsx.hbs
@@ -69,7 +69,7 @@ export function {{ pageName page }}({ close, result } : {{ pageName page }}Props
     const [isLoading, setIsLoading] = useState<boolean>(false);
     const [data, setData] = useState<{{ classDataName page.dataElement.target '' }}>({ ...result });
     const [validation, setValidation] = useState<Map<keyof {{ classDataName page.dataElement.target '' }}, string>>(new Map());
-    const [editMode] = useState<boolean>(false);
+    const [editMode, setEditMode] = useState<boolean>(false);
     const { openRangeDialog } = useRangeDialog();
     const [payloadDiff] = useState<Record<keyof {{ classDataName page.dataElement.target '' }}, any>>({} as unknown as Record<keyof {{ classDataName page.dataElement.target '' }}, any>);
     const storeDiff: (attributeName: keyof {{ classDataName page.dataElement.target '' }}, value: any) => void = useCallback((attributeName: keyof {{ classDataName page.dataElement.target '' }}, value: any) => {

--- a/judo-ui-react/src/main/resources/actor/src/pages/actions/actionForm/createActionForm.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/actions/actionForm/createActionForm.tsx.hbs
@@ -64,7 +64,7 @@ import { CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY, CustomFormVisualElementProps } fro
           __referenceId: uuidv1(),
         } as unknown as {{ classDataName page.dataElement.target '' }});
         const [validation, setValidation] = useState<Map<keyof {{ classDataName page.dataElement.target '' }}, string>>(new Map());
-        const [editMode] = useState<boolean>(true);
+        const [editMode, setEditMode] = useState<boolean>(true);
         const [payloadDiff] = useState<Record<keyof {{ classDataName page.dataElement.target '' }}, any>>({} as unknown as Record<keyof {{ classDataName page.dataElement.target '' }}, any>);
         const storeDiff: (attributeName: keyof {{ classDataName page.dataElement.target '' }}, value: any) => void = useCallback((attributeName: keyof {{ classDataName page.dataElement.target '' }}, value: any) => {
             payloadDiff[attributeName] = value;

--- a/judo-ui-react/src/main/resources/actor/src/pages/actions/actionForm/operationInputActionForm.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/actions/actionForm/operationInputActionForm.tsx.hbs
@@ -61,7 +61,7 @@ import { CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY, CustomFormVisualElementProps } fro
         const [isLoading, setIsLoading] = useState<boolean>(false);
         const [data, setData] = useState<{{ classDataName action.inputParameterPage.dataElement.target '' }}>({} as unknown as {{ classDataName action.inputParameterPage.dataElement.target '' }});
         const [validation, setValidation] = useState<Map<keyof {{ classDataName action.inputParameterPage.dataElement.target '' }}, string>>(new Map());
-        const [editMode] = useState<boolean>(true);
+        const [editMode, setEditMode] = useState<boolean>(true);
         const [payloadDiff] = useState<Record<keyof {{ classDataName action.inputParameterPage.dataElement.target '' }}, any>>({} as unknown as Record<keyof {{ classDataName action.inputParameterPage.dataElement.target '' }}, any>);
         const storeDiff: (attributeName: keyof {{ classDataName action.inputParameterPage.dataElement.target '' }}, value: any) => void = useCallback((attributeName: keyof {{ classDataName action.inputParameterPage.dataElement.target '' }}, value: any) => {
             payloadDiff[attributeName] = value;

--- a/judo-ui-react/src/main/resources/actor/src/pages/operation-output/view.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/operation-output/view.hbs
@@ -110,23 +110,8 @@ export default function {{ pageName page }}() {
                     label: t('judo.pages.table.remove', { defaultValue: 'Remove' }) as string,
                     icon: <MdiIcon path="link_off" />,
                     action: async (row: {{ classDataName table.dataElement.target 'Stored' }}) => {
-                        if (editMode) {
-                            storeDiff('{{ table.dataElement.name }}', [...(data.{{ table.dataElement.name }} || []).filter((e: {{ classDataName table.dataElement.target 'Stored' }}) => e.__signedIdentifier !== row.__signedIdentifier)]);
-                        } else {
-                            try {
-                                await {{ classServiceName table.dataElement.owner }}Impl.remove{{ firstToUpper table.dataElement.name }}(
-                                    { __signedIdentifier: data.__signedIdentifier } as JudoIdentifiable<{{ classDataName table.dataElement.owner '' }}>,
-                                    [row],
-                                );
-
-                                fetchData();
-                            } catch (error) {
-                                enqueueSnackbar(t('judo.component.Table.error.remove', { defaultValue: 'Could not remove element!' }) as string, {
-                                    variant: 'error',
-                                });
-                                console.error(error);
-                            }
-                        }
+                        setEditMode(true);
+                        storeDiff('{{ table.dataElement.name }}', [...(data.{{ table.dataElement.name }} || []).filter((e: {{ classDataName table.dataElement.target 'Stored' }}) => e.__signedIdentifier !== row.__signedIdentifier)]);
                     },
                 },
             {{/ if }}
@@ -137,7 +122,7 @@ export default function {{ pageName page }}() {
                         label: t('judo.pages.table.delete', { defaultValue: 'Delete' }) as string,
                         icon: <MdiIcon path="{{ action.icon.name }}" />,
                         action: async (row: {{ classDataName table.dataElement.target 'Stored' }}) => {{ actionFunctionName action page }}({{# if (hasDataElementOwner action.dataElement) }}data, {{/ if }}row, () => fetchData()),
-                        disabled: (row: {{ classDataName table.dataElement.target 'Stored' }}) => !row.__deleteable,
+                        disabled: (row: {{ classDataName table.dataElement.target 'Stored' }}) => editMode || !row.__deleteable,
                     },
                 {{/ if }}
                 {{# if action.isCallOperationAction }}
@@ -146,6 +131,7 @@ export default function {{ pageName page }}() {
                         label: t('{{ idToTranslationKey action.fQName application }}', { defaultValue: '{{ action.label }}' }) as string,
                         icon: <MdiIcon path="{{ action.icon.name }}" />,
                         action: async (row: {{ classDataName table.dataElement.target 'Stored' }}) => {{ actionFunctionName action page }}({{# if action.operation.isMapped }}row, {{/ if }}() => fetchData()),
+                        disabled: (row: {{ classDataName table.dataElement.target 'Stored' }}) => editMode,
                     },
                 {{/ if }}
             {{/ each }}
@@ -228,60 +214,7 @@ export default function {{ pageName page }}() {
         <>
             {{# with (getDataContainerForPage page) as |rootChild| }}
                 <PageHeader title={title}>
-                    {{# if page.dataElement.isRefreshable }}
-                        {!editMode && (
-                            <Grid item>
-                                <Button id="page-action-refresh" onClick={() => fetchData()} disabled={isLoading}>
-                                    <MdiIcon path="refresh" />
-                                    {t('judo.pages.refresh', { defaultValue: 'Refresh' })}
-                                </Button>
-                            </Grid>
-                        )}
-                    {{/ if }}
-                    {{# if page.dataElement.isDeletable }}
-                        {!editMode && (
-                            <Grid item>
-                                <Button id="page-action-delete" onClick={() => deleteData()} disabled={isLoading || !data.__deleteable}>
-                                    <MdiIcon path="delete" />
-                                    {t('judo.pages.delete', { defaultValue: 'Delete' })}
-                                </Button>
-                            </Grid>
-                        )}
-                    {{/ if }}
-                    {{# if page.dataElement.isUpdatable }}
-                        {!editMode && (
-                            <Grid item>
-                                <Button id="page-action-edit" onClick={() => setEditMode(true)} disabled={isLoading || !data.__updateable}>
-                                    <MdiIcon path="pencil" />
-                                    {t('judo.pages.edit', { defaultValue: 'Edit' })}
-                                </Button>
-                            </Grid>
-                        )}
-                        {editMode && (
-                            <Grid item>
-                                <Button
-                                    id="page-action-edit-cancel"
-                                    variant="outlined"
-                                    onClick={() => {
-                                        setEditMode(false);
-                                        fetchData();
-                                    }}
-                                    disabled={isLoading}
-                                >
-                                    <MdiIcon path="cancel" />
-                                    {t('judo.pages.cancel', { defaultValue: 'Cancel' })}
-                                </Button>
-                            </Grid>
-                        )}
-                        {editMode && (
-                            <Grid item>
-                                <Button id="page-action-edit-save" onClick={() => saveData()} disabled={isLoading}>
-                                    <MdiIcon path="content-save" />
-                                    {t('judo.pages.save', { defaultValue: 'Save' })}
-                                </Button>
-                            </Grid>
-                        )}
-                    {{/ if }}
+                    {{> actor/src/fragments/page/page-crud-actions.hbs }}
                 </PageHeader>
                 <Container component="main" maxWidth="xl">
                     <Box sx={mainContainerPadding}>

--- a/judo-ui-react/src/main/resources/actor/src/pages/relation/view.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/relation/view.hbs
@@ -122,23 +122,8 @@ export default function {{ pageName page }}() {
                     label: t('judo.pages.table.remove', { defaultValue: 'Remove' }) as string,
                     icon: <MdiIcon path="link_off" />,
                     action: async (row: {{ classDataName table.dataElement.target 'Stored' }}) => {
-                        if (editMode) {
-                            storeDiff('{{ table.dataElement.name }}', [...(data.{{ table.dataElement.name }} || []).filter((e: {{ classDataName table.dataElement.target 'Stored' }}) => e.__signedIdentifier !== row.__signedIdentifier)]);
-                        } else {
-                            try {
-                                await {{ classServiceName table.dataElement.owner }}Impl.remove{{ firstToUpper table.dataElement.name }}(
-                                    { __signedIdentifier: data.__signedIdentifier } as JudoIdentifiable<{{ classDataName table.dataElement.owner '' }}>,
-                                    [row],
-                                );
-
-                                fetchData();
-                            } catch (error) {
-                                enqueueSnackbar(t('judo.component.Table.error.remove', { defaultValue: 'Could not remove element!' }) as string, {
-                                    variant: 'error',
-                                });
-                                console.error(error);
-                            }
-                        }
+                        setEditMode(true);
+                        storeDiff('{{ table.dataElement.name }}', [...(data.{{ table.dataElement.name }} || []).filter((e: {{ classDataName table.dataElement.target 'Stored' }}) => e.__signedIdentifier !== row.__signedIdentifier)]);
                     },
                 },
             {{/ if }}
@@ -149,7 +134,7 @@ export default function {{ pageName page }}() {
                         label: t('judo.pages.table.delete', { defaultValue: 'Delete' }) as string,
                         icon: <MdiIcon path="{{ action.icon.name }}" />,
                         action: async (row: {{ classDataName table.dataElement.target 'Stored' }}) => {{ actionFunctionName action page }}({{# if (hasDataElementOwner action.dataElement) }}data, {{/ if }}row, () => fetchData()),
-                        disabled: (row: {{ classDataName table.dataElement.target 'Stored' }}) => !row.__deleteable,
+                        disabled: (row: {{ classDataName table.dataElement.target 'Stored' }}) => editMode || !row.__deleteable,
                     },
                 {{/ if }}
                 {{# if action.isCallOperationAction }}
@@ -158,6 +143,7 @@ export default function {{ pageName page }}() {
                         label: t('{{ idToTranslationKey action.fQName application }}', { defaultValue: '{{ action.label }}' }) as string,
                         icon: <MdiIcon path="{{ action.icon.name }}" />,
                         action: async (row: {{ classDataName table.dataElement.target 'Stored' }}) => {{ actionFunctionName action page }}({{# if action.operation.isMapped }}row, {{/ if }}() => fetchData()),
+                        disabled: (row: {{ classDataName table.dataElement.target 'Stored' }}) => editMode,
                     },
                 {{/ if }}
             {{/ each }}
@@ -239,60 +225,7 @@ export default function {{ pageName page }}() {
         <>
             {{# with (getDataContainerForPage page) as |rootChild| }}
                 <PageHeader title={title}>
-                    {{# if page.relationType.isRefreshable }}
-                        {!editMode && (
-                            <Grid item>
-                                <Button id="page-action-refresh" onClick={() => fetchData()} disabled={isLoading}>
-                                    <MdiIcon path="refresh" />
-                                    {t('judo.pages.refresh', { defaultValue: 'Refresh' })}
-                                </Button>
-                            </Grid>
-                        )}
-                    {{/ if }}
-                    {{# if page.relationType.isDeletable }}
-                        {!editMode && (
-                            <Grid item>
-                                <Button id="page-action-delete" onClick={() => deleteData()} disabled={isLoading || !data.__deleteable}>
-                                    <MdiIcon path="delete" />
-                                    {t('judo.pages.delete', { defaultValue: 'Delete' })}
-                                </Button>
-                            </Grid>
-                        )}
-                    {{/ if }}
-                    {{# if page.relationType.isUpdatable }}
-                        {!editMode && (
-                            <Grid item>
-                                <Button id="page-action-edit" onClick={() => setEditMode(true)} disabled={isLoading || !data.__updateable}>
-                                    <MdiIcon path="pencil" />
-                                    {t('judo.pages.edit', { defaultValue: 'Edit' })}
-                                </Button>
-                            </Grid>
-                        )}
-                        {editMode && (
-                            <Grid item>
-                                <Button
-                                    id="page-action-edit-cancel"
-                                    variant="outlined"
-                                    onClick={() => {
-                                        setEditMode(false);
-                                        fetchData();
-                                    }}
-                                    disabled={isLoading}
-                                >
-                                    <MdiIcon path="cancel" />
-                                    {t('judo.pages.cancel', { defaultValue: 'Cancel' })}
-                                </Button>
-                            </Grid>
-                        )}
-                        {editMode && (
-                            <Grid item>
-                                <Button id="page-action-edit-save" onClick={() => saveData()} disabled={isLoading}>
-                                    <MdiIcon path="content-save" />
-                                    {t('judo.pages.save', { defaultValue: 'Save' })}
-                                </Button>
-                            </Grid>
-                        )}
-                    {{/ if }}
+                    {{> actor/src/fragments/page/page-crud-actions.hbs }}
                 </PageHeader>
                 <Container component="main" maxWidth="xl">
                     <Box sx={mainContainerPadding}>

--- a/judo-ui-react/src/main/resources/actor/src/pages/widgets/button.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/widgets/button.hbs
@@ -23,10 +23,8 @@
         {{# if action.isNavigationToPageAction }}
             {{# if action.dataElement.isCollection }}
                 <CollectionAssociationButton id="{{ createId action }}" editMode={editMode} navigateAction={() => {{ actionFunctionName action page }}(data)}>
-                    {{# if child.icon }}
-                        <MdiIcon path="{{ child.icon.name }}" />
-                    {{/ if }}
                     { t('{{ idToTranslationKey child.fQName application }}', { defaultValue: '{{ child.label }}' }) }
+                    <MdiIcon path="arrow-right" />
                 </CollectionAssociationButton>
             {{ else }}
                 <AssociationButton
@@ -37,10 +35,8 @@
                         _mask: '{}',
                     })}
                 >
-                    {{# if child.icon }}
-                        <MdiIcon path="{{ child.icon.name }}" />
-                    {{/ if }}
                     { t('{{ idToTranslationKey child.fQName application }}', { defaultValue: '{{ child.label }}' }) }
+                    <MdiIcon path="arrow-right" />
                 </AssociationButton>
             {{/ if }}
         {{/ if }}

--- a/judo-ui-react/src/main/resources/actor/src/pages/widgets/link.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/widgets/link.hbs
@@ -25,7 +25,8 @@
         {{# if child.icon }}
             icon={<MdiIcon path="{{ child.icon.name }}" />}
         {{/ if }}
-        readonly={ {{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} {{ boolValue child.dataElement.isReadOnly }} || !editMode }
+        disabled={ {{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} {{ boolValue child.dataElement.isReadOnly }} }
+        editMode={ editMode }
         {{# each child.actions as |action| }}
             {{# if action.isViewAction }}
                 onView={ async () => {{ actionFunctionName action page }}({{# unless (isActionAccess action) }}data?.{{ child.dataElement.name }}!{{/ unless }}) }
@@ -69,16 +70,14 @@
 
                 if (res === undefined) return;
 
+                setEditMode(true);
                 storeDiff('{{ child.dataElement.name }}', res as {{ classDataName child.dataElement.target 'Stored' }});
             } }
         {{/ if }}
         {{# if child.dataElement.isUnsetable }}
             onUnset={ async () => {
-                if (editMode) {
-                    storeDiff('{{ child.dataElement.name }}', null);
-                } else {
-                    alert('Unset action on Link Component in View Mode not implemented yet')
-                }
+                setEditMode(true);
+                storeDiff('{{ child.dataElement.name }}', null);
             } }
         {{/ if }}
     />

--- a/judo-ui-react/src/main/resources/actor/src/pages/widgets/table.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/widgets/table.hbs
@@ -20,7 +20,11 @@
             disableSelectionOnClick
             {{# each child.rowActions as |action| }}
                 {{# if action.isViewAction }}
-                    onRowClick={ (params: GridRowParams<{{ classDataName child.dataElement.target 'Stored' }}>) => {{ actionFunctionName action action.target }}(params.row) }
+                    onRowClick={ (params: GridRowParams<{{ classDataName child.dataElement.target 'Stored' }}>) => {
+                        if (!editMode) {
+                            {{ actionFunctionName action action.target }}(params.row);
+                        }
+                    } }
                 {{/ if }}
             {{/ each }}
             sortModel={ {{ child.dataElement.name }}SortModel }
@@ -60,7 +64,7 @@
 
                                         {{# if page.dataElement.isUpdatable }}
                                             if (!editMode) {
-                                                saveData();
+                                                setEditMode(true);
                                             }
                                         {{/ if }}
                                     }
@@ -80,7 +84,7 @@
 
                                     {{# if page.dataElement.isUpdatable }}
                                         if (!editMode) {
-                                            saveData();
+                                            setEditMode(true);
                                         }
                                     {{/ if }}
                                 } }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-4686" title="JNG-4686" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-4686</a>  Composition -> Association actions are missing on React frontend tables
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

- refactor AggregationInput component to better reflect modifiers (disabled, editMode), also if applicable, allows set/unset/remove actions with implicit change to edit mode
- AssociationButtons are now text variants, with icon representing navigation
- fixed page action bar, now it's sticky
- extracted Page CRUD actions to dedicated fragment
- fixed table row click action, now it doesn't navigate in edit mode
- fixed back button visibility