### PR TITLE
JNG-4835 fix filter attribute can not be filtered more than once

### DIFF
--- a/judo-ui-react/src/main/resources/actor/src/components/dialog/FilterDialog.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/dialog/FilterDialog.tsx.hbs
@@ -415,7 +415,7 @@ export const FilterDialog = ({ id, filters, filterOptions, resolve, open, handle
                           setTempFilters((prevTempFilters) => [
                             ...prevTempFilters,
                             {
-                              id: filterOption.id,
+                              id: filterOption.id + prevTempFilters.filter(e => e.filterOption.label == filterOption.label).length,
                               operationId: `${filterOption.id}-operation`,
                               valueId: `${filterOption.id}-value`,
                               filterOption: {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-4835" title="JNG-4835" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-4835</a>  An attribute cannot be filtered more than once, because if you change the operation or input value in one, the others will also change
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
