### PR TITLE
JNG-5023 fix autocomplete loading indicator

### DIFF
--- a/judo-ui-react/src/main/resources/actor/src/components/widgets/AggregationInput.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/widgets/AggregationInput.tsx.hbs
@@ -89,11 +89,14 @@ export const AggregationInput = ({
   const handleSearch = async (searchText: string) => {
     try {
       if (onAutoCompleteSearch) {
+        setLoading(true);
         const data = await onAutoCompleteSearch(searchText);
         setOptions(data);
       }
     } catch (error) {
       // Handle error
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -158,7 +161,7 @@ export const AggregationInput = ({
                 startAdornment: icon && <InputAdornment position="start" style={ { marginTop: 0 } }>{icon}</InputAdornment>,
                 endAdornment: (
                   <>
-                    {loading ? <CircularProgress color="inherit" size={20} /> : null}
+                    {loading ? <CircularProgress color="inherit" size='1rem' sx={ { mt: -2 } } /> : null}
                     {params.InputProps.endAdornment}
                   </>
                 ),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5023" title="JNG-5023" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-5023</a>  autocomplete loading indicator is not visible
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
![aggr-loading](https://github.com/BlackBeltTechnology/judo-ui-react-template/assets/1084847/d6826b35-ab6e-4d35-a124-16a3bc7cd861)
