### PR TITLE
JNG-5031 naming collision

### DIFF
--- a/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/UiServiceHelper.java
+++ b/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/UiServiceHelper.java
@@ -55,7 +55,7 @@ public class UiServiceHelper extends Helper {
     }
 
     public static String classServiceName(ClassType classType) {
-        return variable(nameWithoutModel(classType.getName()) + "Service");
+        return variable(nameWithoutModel(classType.getName()) + "ServiceForClass");
     }
 
     public static String classServiceTypeName(ClassType classType) {

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 
         <judo-meta-ui-version>1.1.0.20230530_152508_0bc4a2ff_develop</judo-meta-ui-version>
         <judo-generator-commons-version>1.0.0.20230516_090341_cd4dbd1a_develop</judo-generator-commons-version>
-        <judo-ui-typescript-rest-version>1.0.0.20230615_180444_1804886f_feature_JNG_4912_faster_reckless</judo-ui-typescript-rest-version>
+        <judo-ui-typescript-rest-version>1.0.0.20230731_154944_917781a4_bugfix_JNG_5031_naming_collision</judo-ui-typescript-rest-version>
 
         <surefire-version>3.0.0-M7</surefire-version>
         <!--suppress UnresolvedMavenProperty -->


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5031" title="JNG-5031" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-5031</a>  React frontend build fails if ESM transferobjects' names ends with Service
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

