### PR TITLE
JNG-5038 fix tab translation

### DIFF
--- a/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/UiI18NHelper.java
+++ b/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/UiI18NHelper.java
@@ -296,11 +296,12 @@ public class UiI18NHelper extends Helper {
 
             for (Tab tab: controller.getTabs()) {
                 Flex nested = (Flex) tab.getElement();
-                translations.put(getTranslationKeyForFlex(nested), nested.getLabel());
 
                 for (VisualElement tabElementChild: nested.getChildren()) {
                     addTranslationsForVisualElement(tabElementChild, translations);
                 }
+
+                translations.put(getTranslationKeyForFlex(nested), nested.getLabel());
             }
         } else if (visualElement instanceof Text text) {
             translations.put(getTranslationKeyForVisualElement(text), text.getText());
@@ -313,12 +314,6 @@ public class UiI18NHelper extends Helper {
         if (visualElement instanceof Container) {
             for (VisualElement element: ((Container) visualElement).getChildren()) {
                 addTranslationsForVisualElement(element, translations);
-            }
-        }
-
-        if (visualElement instanceof TabController) {
-            for (Tab tab: ((TabController) visualElement).getTabs()) {
-                addTranslationsForVisualElement(tab.getElement(), translations);
             }
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5038" title="JNG-5038" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-5038</a>  If 2 visual components has the same name but with different case and component type only one entry for translation is generated leading to inconsistency on page labeling
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
