### PR TITLE
JNG-5097 add create to selector modals

### DIFF
--- a/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/UiWidgetHelper.java
+++ b/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/UiWidgetHelper.java
@@ -309,4 +309,8 @@ public class UiWidgetHelper extends Helper {
 
         return column != null;
     }
+
+    public static Action getCreateActionForLink(Link link) {
+        return link.getActions().stream().filter(Action::getIsCreateAction).findAny().get();
+    }
 }

--- a/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/UiWidgetHelper.java
+++ b/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/UiWidgetHelper.java
@@ -311,6 +311,10 @@ public class UiWidgetHelper extends Helper {
     }
 
     public static Action getCreateActionForLink(Link link) {
-        return link.getActions().stream().filter(Action::getIsCreateAction).findAny().get();
+        return link.getActions().stream().filter(Action::getIsCreateAction).findAny().orElse(null);
+    }
+
+    public static boolean linkHasCreateAction(Link link) {
+        return getCreateActionForLink(link) != null;
     }
 }

--- a/judo-ui-react/src/main/resources/actor/public/i18n/system_default.json.hbs
+++ b/judo-ui-react/src/main/resources/actor/public/i18n/system_default.json.hbs
@@ -47,6 +47,7 @@
         "judo.modal.range.set-filters": "Set filters",
         "judo.modal.range.cancel": "Cancel",
         "judo.modal.range.submit": "Select",
+        "judo.modal.range.create-blocked-edit-mode": "Creating new elements is disabled because you have unsaved changes",
         "judo.files.no-file-present": "No file present",
         "judo.files.upload-success": "\{{fileName}} successfully uploaded.",
         "judo.files.upload-error": "There was an error while the file was being uploaded!",

--- a/judo-ui-react/src/main/resources/actor/public/i18n/system_en-US.json.hbs
+++ b/judo-ui-react/src/main/resources/actor/public/i18n/system_en-US.json.hbs
@@ -47,6 +47,7 @@
         "judo.modal.range.set-filters": "Set filters",
         "judo.modal.range.cancel": "Cancel",
         "judo.modal.range.submit": "Select",
+        "judo.modal.range.create-blocked-edit-mode": "Creating new elements is disabled because you have unsaved changes",
         "judo.files.no-file-present": "No file present",
         "judo.files.upload-success": "\{{fileName}} successfully uploaded.",
         "judo.files.upload-error": "There was an error while the file was being uploaded!",

--- a/judo-ui-react/src/main/resources/actor/public/i18n/system_hu-HU.json.hbs
+++ b/judo-ui-react/src/main/resources/actor/public/i18n/system_hu-HU.json.hbs
@@ -47,6 +47,7 @@
         "judo.modal.range.set-filters": "Szűrő beállítása",
         "judo.modal.range.cancel": "Mégsem",
         "judo.modal.range.submit": "Kiválasztás",
+        "judo.modal.range.create-blocked-edit-mode": "Új elem létrehozása nem lehetséges, mert nem mentett módosítások vannak a képernyőn",
         "judo.files.no-file-present": "Nincs fájl feltöltve",
         "judo.files.upload-success": "\{{fileName}} sikeresen feltöltve.",
         "judo.files.upload-error": "Hiba történt a fájl feltöltés közben!",

--- a/judo-ui-react/src/main/resources/actor/src/components-api/dialog/DialogContext.ts.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components-api/dialog/DialogContext.ts.hbs
@@ -26,12 +26,14 @@ export interface OpenRangeDialogProps<T extends JudoStored<T>, U extends QueryCu
   alreadySelectedItems: GridRowSelectionModel | GridRowId;
   initialQueryCustomizer: U;
   filterOptions: FilterOption[];
+  createTrigger?: () => Promise<T | undefined>;
+  editMode?: boolean;
 }
 
 export interface RangeDialogProviderContext {
   openRangeDialog: <T extends JudoStored<T>, U extends QueryCustomizer<T>>(
     props: OpenRangeDialogProps<T, U>,
-  ) => Promise<T[] | T>;
+  ) => Promise<{ value: T[] | T, resolveSource: 'selection' | 'create' }>;
 }
 
 export interface FilterDialogProviderContext {

--- a/judo-ui-react/src/main/resources/actor/src/components/dialog/DialogProvider.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/dialog/DialogProvider.tsx.hbs
@@ -61,10 +61,12 @@ export const DialogProvider = ({ children }: DialogProviderProps) => {
     alreadySelectedItems,
     filterOptions,
     initialQueryCustomizer,
+    createTrigger,
+    editMode,
   }: OpenRangeDialogProps<T, U>) => {
     setIsOpenRangeDialog(true);
 
-    return new Promise<T[] | T>((resolve) => {
+    return new Promise<{ value: T[] | T, resolveSource: 'selection' | 'create' }>((resolve) => {
       setRangeDialog(
         <RangeDialog<T, U>
           id={id}
@@ -78,6 +80,8 @@ export const DialogProvider = ({ children }: DialogProviderProps) => {
           alreadySelectedItems={alreadySelectedItems}
           filterOptions={filterOptions}
           initalQueryCustomizer={initialQueryCustomizer}
+          createTrigger={createTrigger}
+          editMode={editMode}
         />,
       );
     });

--- a/judo-ui-react/src/main/resources/actor/src/components/dialog/RangeDialog.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/dialog/RangeDialog.tsx.hbs
@@ -1,6 +1,6 @@
 {{> fragment.header.hbs }}
 
-import { Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button } from '@mui/material';
+import { Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button, Typography } from '@mui/material';
 import type {
   GridSortModel,
   GridRowModel,
@@ -48,6 +48,8 @@ interface RangeDialogProps<T extends JudoStored<T>, U extends QueryCustomizer<T>
   alreadySelectedItems: GridRowSelectionModel | GridRowId;
   initalQueryCustomizer: U;
   filterOptions: FilterOption[];
+  createTrigger?: () => Promise<T | undefined>;
+  editMode?: boolean;
 }
 
 export const RangeDialog = <T extends JudoStored<T>, U extends QueryCustomizer<T>>({
@@ -62,6 +64,8 @@ export const RangeDialog = <T extends JudoStored<T>, U extends QueryCustomizer<T
   alreadySelectedItems,
   initalQueryCustomizer,
   filterOptions,
+  createTrigger,
+  editMode,
 }: RangeDialogProps<T, U>) => {
   const { openFilterDialog } = useFilterDialog();
   const { t } = useTranslation();
@@ -215,7 +219,10 @@ export const RangeDialog = <T extends JudoStored<T>, U extends QueryCustomizer<T
 
   const ok = () => {
     handleClose();
-    resolve(selectedItems);
+    resolve({
+      value: selectedItems,
+      resolveSource: 'selection',
+    });
   };
 
   const handleOnSelection = (newSelectionModel: GridRowSelectionModel) => {
@@ -341,6 +348,30 @@ export const RangeDialog = <T extends JudoStored<T>, U extends QueryCustomizer<T
                   >
                     { t('judo.modal.range.set-filters', { defaultValue: 'Set filters' }) as string } {filters.length !== 0 ? '(' + filters.length + ')' : ''}
                   </Button>
+                  {createTrigger && (
+                    <Button
+                      id={`${id}-create`}
+                      variant="text"
+                      startIcon={<MdiIcon path="file_document_plus" />}
+                      onClick={async () => {
+                        try {
+                          const result = await createTrigger();
+                          if (result) {
+                            handleClose();
+                            resolve({
+                              value: result,
+                              resolveSource: 'create',
+                            });
+                          }
+                        } catch (error) {
+                          console.error(error);
+                        }
+                      }}
+                      disabled={isLoading || editMode}
+                    >
+                      {t('judo.pages.table.create', { defaultValue: 'Create' })}
+                    </Button>
+                  ) }
                 </GridToolbarContainer>
               ),
               Pagination: () => (
@@ -374,6 +405,9 @@ export const RangeDialog = <T extends JudoStored<T>, U extends QueryCustomizer<T
               } }
             />
           {{/ if }}
+          {editMode && createTrigger && <Typography sx={ { fontStyle: 'italic' } }>
+            {t('judo.modal.range.create-blocked-edit-mode', { defaultValue: 'Creating new elements is disabled because you have unsaved changes' })}
+          </Typography>}
         </DialogContentText>
       </DialogContent>
       <DialogActions>

--- a/judo-ui-react/src/main/resources/actor/src/pages/actions/action/add-action.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/actions/action/add-action.tsx.hbs
@@ -90,7 +90,7 @@ export const {{ actionFunctionHookName action }}: {{ actionFunctionTypeName acti
             try {
                 await {{ classServiceName action.dataElement.owner }}Impl.add{{ firstToUpper action.dataElement.name }}(
                     { __signedIdentifier: owner.__signedIdentifier } as JudoIdentifiable<{{ classDataName action.dataElement.target 'Stored' }}>,
-                    res as Array<{{ classDataName action.dataElement.target 'Stored' }}>,
+                    res.value as Array<{{ classDataName action.dataElement.target 'Stored' }}>,
                 );
 
                 successCallback();

--- a/judo-ui-react/src/main/resources/actor/src/pages/actions/action/call-operation-action/output-view/components/link.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/actions/action/call-operation-action/output-view/components/link.tsx.hbs
@@ -93,7 +93,7 @@ export function {{ linkComponentName link }}(props: {{ linkComponentName link }}
                         });
 
                         if (res === undefined) return;
-                        storeDiff('{{ link.dataElement.name }}', res as {{ classDataName link.dataElement.target 'Stored' }});
+                        storeDiff('{{ link.dataElement.name }}', res.value as {{ classDataName link.dataElement.target 'Stored' }});
                     } }
                     {{# if (isAutocompleteAvailable link) }}
                         {{# with (getFirstAutocompleteColumnForLink link) as |column| }}

--- a/judo-ui-react/src/main/resources/actor/src/pages/actions/action/call-operation-action/without-input-form.fragment.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/actions/action/call-operation-action/without-input-form.fragment.hbs
@@ -58,7 +58,7 @@ return async function {{ actionFunctionName action }} ({{# if action.operation.i
     {{/ if }}
 
     try {
-        const result = await {{ classServiceName action.dataElement.owner }}Impl.{{ action.dataElement.name }}({{# if action.operation.isMapped }}owner{{/ if }}{{# if action.operation.input }}{{# if action.operation.isMapped }},{{/ if }}res as {{ classDataName action.inputParameterPage.dataElement.target 'Stored' }}{{/ if }});
+        const result = await {{ classServiceName action.dataElement.owner }}Impl.{{ action.dataElement.name }}({{# if action.operation.isMapped }}owner{{/ if }}{{# if action.operation.input }}{{# if action.operation.isMapped }},{{/ if }}res.value as {{ classDataName action.inputParameterPage.dataElement.target 'Stored' }}{{/ if }});
         if (postHandler) {
             postHandler(successCallback{{# if action.outputParameterPage }}, result{{/ if }});
             return;

--- a/judo-ui-react/src/main/resources/actor/src/pages/actions/action/create-action.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/actions/action/create-action.tsx.hbs
@@ -36,7 +36,11 @@ import {
 {{/ unless }}
 import { {{ pageActionFormComponentName action }} } from './{{ pageActionFormComponentName action }}';
 
-export type {{ actionFunctionTypeName action }} = () => ({{# unless (isActionAccess action) }}owner: JudoIdentifiable<{{ classDataName action.dataElement.target '' }}>,{{/ unless }}successCallback: () => void) => void;
+export type {{ actionFunctionTypeName action }} = () => (
+  {{# unless (isActionAccess action) }}owner: JudoIdentifiable<{{ classDataName action.dataElement.target '' }}>,{{/ unless }}
+  successCallback: (result: {{ classDataName action.dataElement.target 'Stored' }}) => void,
+  closedCallback?: () => void,
+) => void;
 
 export const {{ actionFunctionHookName action }}: {{ actionFunctionTypeName action }} = () => {
     const [createDialog, closeDialog] = useDialog();
@@ -47,26 +51,30 @@ export const {{ actionFunctionHookName action }}: {{ actionFunctionTypeName acti
     {{/ unless }}
     const { enqueueSnackbar } = useSnackbar();
 
-    return function {{ actionFunctionName action }} ({{# unless (isActionAccess action) }}owner: JudoIdentifiable<{{ classDataName action.dataElement.target '' }}>,{{/ unless }}successCallback: () => void) {
+    return function {{ actionFunctionName action }} ({{# unless (isActionAccess action) }}owner: JudoIdentifiable<{{ classDataName action.dataElement.target '' }}>,{{/ unless }}successCallback: (result: {{ classDataName action.dataElement.target 'Stored' }}) => void, closedCallback?: () => void) {
         {{# if (actionHasVisualElements action) }}
             createDialog({
                 fullWidth: true,
                 onClose: (event: object, reason: string) => {
                     if (reason !== 'backdropClick') {
                         closeDialog();
+                        closedCallback && closedCallback();
                     }
                 },
                 children: (
                     <{{ pageActionFormComponentName action }}
-                        successCallback={() => {
+                        successCallback={(result: {{ classDataName action.dataElement.target 'Stored' }}) => {
                             closeDialog();
                             enqueueSnackbar(t('judo.action.create.success', { defaultValue: 'Create successful' }), {
                                 variant: 'success',
                                 ...toastConfig.success,
                             });
-                            successCallback();
+                            successCallback(result);
                         }}
-                        cancel={closeDialog}
+                        cancel={ () => {
+                            closeDialog();
+                            closedCallback && closedCallback();
+                        } }
                         {{# unless (isActionAccess action) }}
                             owner={owner}
                         {{/ unless }}

--- a/judo-ui-react/src/main/resources/actor/src/pages/actions/actionForm/components/link.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/actions/actionForm/components/link.tsx.hbs
@@ -93,7 +93,7 @@ export function {{ linkComponentName link }}(props: {{ linkComponentName link }}
                         });
 
                         if (res === undefined) return;
-                        storeDiff('{{ link.dataElement.name }}', res as {{ classDataName link.dataElement.target 'Stored' }});
+                        storeDiff('{{ link.dataElement.name }}', res.value as {{ classDataName link.dataElement.target 'Stored' }});
                     } }
                     {{# if (isAutocompleteAvailable link) }}
                         {{# with (getFirstAutocompleteColumnForLink link) as |column| }}

--- a/judo-ui-react/src/main/resources/actor/src/pages/actions/actionForm/components/table.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/actions/actionForm/components/table.tsx.hbs
@@ -86,7 +86,7 @@ export const {{ tableComponentName table }} = forwardRef<RefreshableTable, {{ ta
                                         if (res) {
                                             storeDiff('{{ table.dataElement.name }}', [
                                                 ...(ownerData.{{ table.dataElement.name }} || []),
-                                                ...(res as {{ classDataName table.dataElement.target 'Stored' }}[])
+                                                ...(res.value as {{ classDataName table.dataElement.target 'Stored' }}[])
                                             ]);
                                         }
                                     } }

--- a/judo-ui-react/src/main/resources/actor/src/pages/actions/actionForm/createActionForm.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/actions/actionForm/createActionForm.tsx.hbs
@@ -32,7 +32,7 @@ import {
 {{/ each }}
 
 export interface {{ pageActionFormComponentName action }}Props {
-    successCallback: () => void;
+    successCallback: (result: {{ classDataName page.dataElement.target 'Stored' }}) => void;
     cancel: () => void;
     {{# if (hasDataElementOwner action.dataElement) }}
         owner: JudoIdentifiable<{{ classDataName ownerPage.dataElement.target '' }}>;
@@ -157,7 +157,7 @@ export function {{ pageActionFormComponentName action }}({
                         <LoadingButton loading={isLoading} loadingPosition="start" id="{{ createId action }}-action-form-action-create" variant="contained" onClick={ async () => {
                                 const result = await saveData();
                                 if (result) {
-                                    successCallback();
+                                    successCallback(result);
                                 }
                             } }>
                             <span>{t('judo.pages.create', { defaultValue: 'Create' })}</span>
@@ -176,7 +176,7 @@ export function {{ pageActionFormComponentName action }}({
                                                 const result: {{ classDataName page.dataElement.target 'Stored' }} | undefined = await saveData();
 
                                                 if (result) {
-                                                    successCallback();
+                                                    successCallback(result);
                                                     {{# unless (pageShouldOpenInDialog (getViewPageForCreatePage page application)) }}
                                                         navigate(routeTo{{ pageName (getViewPageForCreatePage page application) }}(result.__signedIdentifier));
                                                     {{ else }}
@@ -191,7 +191,7 @@ export function {{ pageActionFormComponentName action }}({
                                                                 <{{ pageName (getViewPageForCreatePage page application) }}
                                                                     successCallback={ () => {
                                                                         closeDialog();
-                                                                        successCallback();
+                                                                        successCallback(result);
                                                                     } }
                                                                     cancel={closeDialog}
                                                                     entry={result}

--- a/judo-ui-react/src/main/resources/actor/src/pages/components/link.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/components/link.tsx.hbs
@@ -111,7 +111,7 @@ export function {{ linkComponentName link }}(props: {{ linkComponentName link }}
                             filterOptions: {{ link.dataElement.name }}RangeFilterOptions,
                             initialQueryCustomizer: {{ link.dataElement.name }}InitialQueryCustomizer,
                             editMode: editMode,
-                            {{# if (getCreateActionForLink link)}}
+                            {{# if (linkHasCreateAction link)}}
                                 // If there is a value set we cannot predict if is a persisted value or not. If it's persisted
                                 // then the backend would error out if we wanted to create a new element on the relation, therefore
                                 // we do not allow creation in such cases.
@@ -128,11 +128,15 @@ export function {{ linkComponentName link }}(props: {{ linkComponentName link }}
                         });
 
                         if (res === undefined) return;
+                        {{# if (linkHasCreateAction link)}}
                         if (res && res.resolveSource === 'create') {
                             fetchOwnerData();
                         } else if (res) {
+                        {{/ if }}
                             storeDiff('{{ link.dataElement.name }}', res.value as {{ classDataName link.dataElement.target 'Stored' }});
+                        {{# if (linkHasCreateAction link)}}
                         }
+                        {{/ if }}
                     } }
                     {{# if (isAutocompleteAvailable link) }}
                         {{# with (getFirstAutocompleteColumnForLink link) as |column| }}

--- a/judo-ui-react/src/main/resources/actor/src/pages/components/link.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/components/link.tsx.hbs
@@ -110,10 +110,29 @@ export function {{ linkComponentName link }}(props: {{ linkComponentName link }}
                             alreadySelectedItems: ownerData.{{ link.dataElement.name }}?.__identifier as GridRowId,
                             filterOptions: {{ link.dataElement.name }}RangeFilterOptions,
                             initialQueryCustomizer: {{ link.dataElement.name }}InitialQueryCustomizer,
+                            editMode: editMode,
+                            {{# if (getCreateActionForLink link)}}
+                                // If there is a value set we cannot predict if is a persisted value or not. If it's persisted
+                                // then the backend would error out if we wanted to create a new element on the relation, therefore
+                                // we do not allow creation in such cases.
+                                createTrigger: !ownerData.{{ link.dataElement.name }} ? async () => {
+                                    return new Promise((resolve) => {
+                                        {{ actionFunctionName (getCreateActionForLink link) }}({{# unless (isActionAccess action) }}ownerData, {{/ unless }}(result: {{ classDataName link.dataElement.target 'Stored' }}) => {
+                                            resolve(result);
+                                        }, () => {
+                                            resolve(undefined);
+                                        });
+                                    });
+                                } : undefined,
+                            {{/ if }}
                         });
 
                         if (res === undefined) return;
-                        storeDiff('{{ link.dataElement.name }}', res as {{ classDataName link.dataElement.target 'Stored' }});
+                        if (res && res.resolveSource === 'create') {
+                            fetchOwnerData();
+                        } else if (res) {
+                            storeDiff('{{ link.dataElement.name }}', res.value as {{ classDataName link.dataElement.target 'Stored' }});
+                        }
                     } }
                     {{# if (isAutocompleteAvailable link) }}
                         {{# with (getFirstAutocompleteColumnForLink link) as |column| }}

--- a/judo-ui-react/src/main/resources/actor/src/pages/components/table/for-aggregation.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/components/table/for-aggregation.hbs
@@ -193,7 +193,7 @@ export const {{ tableComponentName table }} = (props: {{ tableComponentName tabl
                                             if (res) {
                                                 storeDiff('{{ table.dataElement.name }}', [
                                                     ...(ownerData.{{ table.dataElement.name }} || []),
-                                                    ...(res as {{ classDataName table.dataElement.target 'Stored' }}[])
+                                                    ...(res.value as {{ classDataName table.dataElement.target 'Stored' }}[])
                                                 ]);
                                             }
                                         } }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5097" title="JNG-5097" target="_blank"><img alt="Story" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />JNG-5097</a>  Create is missing form single mapping relation with create crud on form
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Rules:
- Only works on View screens
- Create is not available if an existing element is persisted on the relation, because backend blows up if we update the relation with new element in this case
- Creating a new element (REST call, relation update) instantly persists it, UI closes the selector and creation dialogs and refreshes the page
- If we are in edit mode and there is no existing element set in the relation, the create button is disabled and a note is displayed under the selector dialog explaining why the user cannot create a new element on the selector it self.
- If we only select a new element from the list instead of creating one, the selector dialog closes, sets the new element in the relation, and triggers edit mode (user has to save the form to persist it). **We are doing this to keep the behavior for all selects**, e.g. selection is available on forms as well, and there we cannot persist changes, etc...
- The following implementation change **DOESN'T WORK**:
  - if the create dialog doesn't call the relation create operation on REST, but sets the data to the relation
  - after which saving the state when an existing value was already set (replace current value with an unsaved one)
  - also triggers a backend error

![create-on-select](https://github.com/BlackBeltTechnology/judo-ui-react-template/assets/1084847/5078a025-99c3-449b-8844-ba94c126dc1d)


