### PR TITLE
JNG-5095 decouple association table refresh from state

### DIFF
--- a/judo-ui-react/src/main/resources/actor/src/pages/access/view.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/access/view.hbs
@@ -65,6 +65,7 @@ export default function {{ pageName page }}() {
     {{/ if }}
     const { enqueueSnackbar } = useSnackbar();
     const [isLoading, setIsLoading] = useState<boolean>(false);
+    const [refreshCounter, setRefreshCounter] = useState<number>(0);
     const [data, setData] = useState<{{ classDataName page.dataElement.target 'Stored' }}>({} as unknown as {{ classDataName page.dataElement.target 'Stored' }});
     const [payloadDiff, setPayloadDiff] = useState<Record<keyof {{ classDataName page.dataElement.target 'Stored' }}, any>>({} as unknown as Record<keyof {{ classDataName page.dataElement.target 'Stored' }}, any>);
     const [editMode, setEditMode] = useState<boolean>(false);
@@ -145,6 +146,7 @@ export default function {{ pageName page }}() {
             handleFetchError(error);
         } finally {
             setIsLoading(false);
+            setRefreshCounter((prevCounter) => prevCounter + 1);
         }
     }
 

--- a/judo-ui-react/src/main/resources/actor/src/pages/components/table/for-association.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/components/table/for-association.hbs
@@ -26,10 +26,11 @@ export interface {{ tableComponentName table }}Props {
     editMode: boolean;
     isFormUpdateable: () => boolean;
     storeDiff: (attributeName: keyof {{ classDataName table.dataElement.owner 'Stored' }}, value: any) => void;
+    refreshCounter: number;
 }
 
 export const {{ tableComponentName table }} = forwardRef<RefreshableTable, {{ tableComponentName table }}Props>((props, ref) => {
-    const { ownerData, fetchOwnerData, editMode, isFormUpdateable } = props;
+    const { ownerData, fetchOwnerData, editMode, isFormUpdateable, refreshCounter } = props;
     const { t } = useTranslation();
     const { openFilterDialog } = useFilterDialog();
     const { openRangeDialog } = useRangeDialog();
@@ -191,7 +192,7 @@ export const {{ tableComponentName table }} = forwardRef<RefreshableTable, {{ ta
 
     useEffect(() => {
         fetchData();
-    }, [queryCustomizer, ownerData]);
+    }, [queryCustomizer, refreshCounter]);
 
     return (
         <>

--- a/judo-ui-react/src/main/resources/actor/src/pages/dialogs/index.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/dialogs/index.tsx.hbs
@@ -67,6 +67,7 @@ export default function {{ pageName page }}(props: {{ pageName page }}Props) {
     {{/ if }}
 
     const [isLoading, setIsLoading] = useState<boolean>(false);
+    const [refreshCounter, setRefreshCounter] = useState<number>(0);
     const [data, setData] = useState<{{ classDataName page.dataElement.target 'Stored' }}>({} as unknown as {{ classDataName page.dataElement.target 'Stored' }});
     const [payloadDiff, setPayloadDiff] = useState<Record<keyof {{ classDataName page.dataElement.target 'Stored' }}, any>>({} as unknown as Record<keyof {{ classDataName page.dataElement.target 'Stored' }}, any>);
     const [editMode, setEditMode] = useState<boolean>(false);
@@ -115,6 +116,7 @@ export default function {{ pageName page }}(props: {{ pageName page }}Props) {
             handleFetchError(error);
         } finally {
             setIsLoading(false);
+            setRefreshCounter((prevCounter) => prevCounter + 1);
         }
     }
 

--- a/judo-ui-react/src/main/resources/actor/src/pages/operation-output/view.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/operation-output/view.hbs
@@ -58,6 +58,7 @@ export default function {{ pageName page }}() {
     {{/ if }}
     const { enqueueSnackbar } = useSnackbar();
     const [isLoading, setIsLoading] = useState<boolean>(false);
+    const [refreshCounter, setRefreshCounter] = useState<number>(0);
     const [data, setData] = useState<{{ classDataName page.dataElement.target 'Stored' }}>({} as unknown as {{ classDataName page.dataElement.target 'Stored' }});
     const [payloadDiff, setPayloadDiff] = useState<Record<keyof {{ classDataName page.dataElement.target 'Stored' }}, any>>({} as unknown as Record<keyof {{ classDataName page.dataElement.target 'Stored' }}, any>);
     const [editMode, setEditMode] = useState<boolean>(false);
@@ -106,6 +107,7 @@ export default function {{ pageName page }}() {
             handleFetchError(error);
         } finally {
             setIsLoading(false);
+            setRefreshCounter((prevCounter) => prevCounter + 1);
         }
     }
 

--- a/judo-ui-react/src/main/resources/actor/src/pages/relation/view.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/relation/view.hbs
@@ -62,6 +62,7 @@ export default function {{ pageName page }}() {
     {{/ if }}
     const { enqueueSnackbar } = useSnackbar();
     const [isLoading, setIsLoading] = useState<boolean>(false);
+    const [refreshCounter, setRefreshCounter] = useState<number>(0);
     const [data, setData] = useState<{{ classDataName page.dataElement.target 'Stored' }}>({} as unknown as {{ classDataName page.dataElement.target 'Stored' }});
     const [payloadDiff, setPayloadDiff] = useState<Record<keyof {{ classDataName page.dataElement.target 'Stored' }}, any>>({} as unknown as Record<keyof {{ classDataName page.dataElement.target 'Stored' }}, any>);
     const [editMode, setEditMode] = useState<boolean>(false);
@@ -110,6 +111,7 @@ export default function {{ pageName page }}() {
             handleFetchError(error);
         } finally {
             setIsLoading(false);
+            setRefreshCounter((prevCounter) => prevCounter + 1);
         }
     }
 

--- a/judo-ui-react/src/main/resources/actor/src/pages/widgets/table.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/widgets/table.hbs
@@ -14,13 +14,16 @@
         <{{ tableComponentName child }}
             isOwnerLoading={isLoading}
             {{# if page.isPageTypeTable }}
-                {{# unless table.dataElement.isAccess }}
+                {{# unless child.dataElement.isAccess }}
                     ownerData={data}
                 {{/ unless }}
                 setIsOwnerLoading={setIsOwnerLoading}
             {{ else }}
                 {{# if (isPageRefreshable page) }}
                     fetchOwnerData={fetchData}
+                {{/ if }}
+                {{# if child.dataElement.isRelationKindAssociation }}
+                    refreshCounter={refreshCounter}
                 {{/ if }}
                 ownerData={data}
                 editMode={editMode}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5095" title="JNG-5095" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-5095</a>  Mapping association with table representation keeps updating on each keystroke during editing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
