### PR TITLE
JNG-5115 Readonly single relation selector should not triggers range call

### DIFF
--- a/judo-ui-react/src/main/resources/actor/src/components/widgets/AggregationInput.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/widgets/AggregationInput.tsx.hbs
@@ -135,8 +135,8 @@ export const AggregationInput = ({
           disabled={disabled}
           readOnly={readOnly || !onAutoCompleteSearch || !onSet}
           onOpen={ () => {
-            setAllowFetch(true);
             if (!readOnly) {
+              setAllowFetch(true);
               handleSearch('');
             }
           } }

--- a/judo-ui-react/src/main/resources/actor/src/components/widgets/AggregationInput.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/widgets/AggregationInput.tsx.hbs
@@ -136,7 +136,9 @@ export const AggregationInput = ({
           readOnly={readOnly || !onAutoCompleteSearch || !onSet}
           onOpen={ () => {
             setAllowFetch(true);
-            handleSearch('');
+            if (!readOnly) {
+              handleSearch('');
+            }
           } }
           isOptionEqualToValue={ (option: any, value: any) => option[autoCompleteAttribute] === value[autoCompleteAttribute] }
           getOptionLabel={ (option) => option[autoCompleteAttribute as keyof JudoStored<any>] as string || '' }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5115" title="JNG-5115" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-5115</a>  Readonly single relation selector triggers range call on focus
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


https://github.com/BlackBeltTechnology/judo-ui-react-template/assets/119794838/0319b472-2aec-4ad7-bc47-b11545bd67ab

