### PR TITLE
JNG-5119 fix automatically update component after closing dialog if it's not i…

### DIFF
--- a/judo-ui-react/src/main/resources/actor/src/pages/dialogs/index.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/dialogs/index.tsx.hbs
@@ -212,13 +212,16 @@ export default function {{ pageName page }}(props: {{ pageName page }}Props) {
                 </DialogContent>
                 <DialogActions>
                     <Grid className="page-action" item>
-                        <Button id="{{ pageName page }}-dialog-close" variant="text" onClick={ () => {
-                          cancel();
-                          if(!editMode) {
-                           successCallback();
-                          }
-                        }}
-                        disabled={isLoading}>
+                        <Button
+                          id="{{ pageName page }}-dialog-close"
+                          variant="text"
+                          onClick={ () => {
+                            cancel();
+                            if(!editMode) {
+                             successCallback();
+                            }
+                          }}
+                          disabled={isLoading}>
                             {t('judo.pages.close', { defaultValue: 'Close' })}
                         </Button>
                     </Grid>

--- a/judo-ui-react/src/main/resources/actor/src/pages/dialogs/index.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/dialogs/index.tsx.hbs
@@ -186,7 +186,12 @@ export default function {{ pageName page }}(props: {{ pageName page }}Props) {
                     <IconButton
                         id="{{ pageName page }}-dialog-close"
                         aria-label="close"
-                        onClick={ () => cancel() }
+                        onClick={ () => {
+                          cancel();
+                          if(!editMode) {
+                           successCallback();
+                          }
+                        }}
                         sx={ {
                             position: 'absolute',
                             right: 8,
@@ -207,7 +212,13 @@ export default function {{ pageName page }}(props: {{ pageName page }}Props) {
                 </DialogContent>
                 <DialogActions>
                     <Grid className="page-action" item>
-                        <Button id="{{ pageName page }}-dialog-close" variant="text" onClick={ () => cancel() } disabled={isLoading}>
+                        <Button id="{{ pageName page }}-dialog-close" variant="text" onClick={ () => {
+                          cancel();
+                          if(!editMode) {
+                           successCallback();
+                          }
+                        }}
+                        disabled={isLoading}>
                             {t('judo.pages.close', { defaultValue: 'Close' })}
                         </Button>
                     </Grid>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5119" title="JNG-5119" target="_blank"><img alt="Task" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />JNG-5119</a>  Automatically update component after closing dialog if it's not in edit mode
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

…n edit mode