### PR TITLE
[DO_NOT_MERGE] JNG-5152 enabled more relation actions

### DIFF
--- a/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/UiGeneralHelper.java
+++ b/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/UiGeneralHelper.java
@@ -199,6 +199,15 @@ public class UiGeneralHelper extends Helper {
                 .collect(Collectors.toList());
     }
 
+    public static List<String> getWritableTablesForClass(ClassType classType) {
+        return classType.getRelations().stream()
+                .filter(ReferenceType::isIsCollection)
+                .filter(r -> !r.isIsReadOnly())
+                .map(NamedElement::getName)
+                .sorted()
+                .collect(Collectors.toList());
+    }
+
     public static boolean hasRelationRange(ReferenceType ref) {
         return ref.getIsRangeable() || ref.getIsSetable() || ref.getIsAddable();
     }

--- a/judo-ui-react/src/main/resources/actor/src/fragments/page/store-diff-body.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/fragments/page/store-diff-body.hbs
@@ -8,12 +8,26 @@
     const timeTypes: string[] = [{{# each (getWritableTimeAttributesForClass classType) as |aName| }}
         '{{ aName }}',
     {{/ each }}];
+    const tableTypes: string[] = [{{# each (getWritableTablesForClass classType) as |aName| }}
+        '{{ aName }}',
+    {{/ each }}];
     if (dateTypes.includes(attributeName as string)) {
         payloadDiff[attributeName] = uiDateToServiceDate(value);
     } else if (dateTimeTypes.includes(attributeName as string)) {
         payloadDiff[attributeName] = value;
     } else if (timeTypes.includes(attributeName as string)) {
         payloadDiff[attributeName] = uiTimeToServiceTime(value);
+    } else if (tableTypes.includes(attributeName as string)) {
+        const filteredList = [];
+        for (const filtered of value) {
+            const shallow = {...filtered};
+            if (shallow.__identifier && shallow.__identifier.startsWith('JUDO_TMP_')) {
+                // remove temp identifier which has been put in place to mitigate mui key errors in tables.
+                delete shallow.__identifier;
+            }
+            filteredList.push(shallow);
+        }
+        payloadDiff[attributeName] = filteredList;
     } else {
         payloadDiff[attributeName] = value;
     }

--- a/judo-ui-react/src/main/resources/actor/src/fragments/table/row-actions.fragment.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/fragments/table/row-actions.fragment.hbs
@@ -12,7 +12,7 @@ const {{ table.dataElement.name }}RowActions: TableRowAction<{{ classDataName ta
                     },
                 {{ else }}
                     action: async (row: {{ classDataName table.dataElement.target 'Stored' }}) => {
-                        storeDiff('{{ table.dataElement.name }}', [...(ownerData.{{ table.dataElement.name }} || []).filter((e: {{ classDataName table.dataElement.target 'Stored' }}) => e.__signedIdentifier !== row.__signedIdentifier)]);
+                        storeDiff('{{ table.dataElement.name }}', [...(ownerData.{{ table.dataElement.name }} || []).filter((e: {{ classDataName table.dataElement.target 'Stored' }}) => e.__identifier !== row.__identifier)]);
                     },
                 {{/ if }}
             },
@@ -27,7 +27,7 @@ const {{ table.dataElement.name }}RowActions: TableRowAction<{{ classDataName ta
                         if (!editMode) {
                             {{ actionFunctionName action }}({{# if (hasDataElementOwner action.dataElement) }}ownerData, {{/ if }}row, () => fetchOwnerData());
                         } else {
-                            storeDiff('{{ table.dataElement.name }}', [...(ownerData.{{ table.dataElement.name }} || []).filter((e: {{ classDataName table.dataElement.target 'Stored' }}) => e.__signedIdentifier !== row.__signedIdentifier)]);
+                            storeDiff('{{ table.dataElement.name }}', [...(ownerData.{{ table.dataElement.name }} || []).filter((e: {{ classDataName table.dataElement.target 'Stored' }}) => e.__identifier !== row.__identifier)]);
                         }
                     },
                     disabled: (row: {{ classDataName table.dataElement.target 'Stored' }}) => {{# if table.enabledBy }}!ownerData.{{ table.enabledBy.name }} ||{{/ if }} (row.__deleteable !== undefined && !row.__deleteable),

--- a/judo-ui-react/src/main/resources/actor/src/fragments/table/row-actions.fragment.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/fragments/table/row-actions.fragment.hbs
@@ -22,8 +22,19 @@ const {{ table.dataElement.name }}RowActions: TableRowAction<{{ classDataName ta
                 id: '{{ createId action }}',
                 label: t('judo.pages.table.delete', { defaultValue: 'Delete' }) as string,
                 icon: <MdiIcon path="{{ action.icon.name }}" />,
-                action: async (row: {{ classDataName table.dataElement.target 'Stored' }}) => {{ actionFunctionName action }}({{# if (hasDataElementOwner action.dataElement) }}ownerData, {{/ if }}row, () => fetchOwnerData()),
-                disabled: (row: {{ classDataName table.dataElement.target 'Stored' }}) => {{# if table.enabledBy }}!ownerData.{{ table.enabledBy.name }} ||{{/ if }} editMode || !row.__deleteable,
+                {{# if table.dataElement.isRelationKindComposition }}
+                    action: async (row: {{ classDataName table.dataElement.target 'Stored' }}) => {
+                        if (!editMode) {
+                            {{ actionFunctionName action }}({{# if (hasDataElementOwner action.dataElement) }}ownerData, {{/ if }}row, () => fetchOwnerData());
+                        } else {
+                            storeDiff('{{ table.dataElement.name }}', [...(ownerData.{{ table.dataElement.name }} || []).filter((e: {{ classDataName table.dataElement.target 'Stored' }}) => e.__signedIdentifier !== row.__signedIdentifier)]);
+                        }
+                    },
+                    disabled: (row: {{ classDataName table.dataElement.target 'Stored' }}) => {{# if table.enabledBy }}!ownerData.{{ table.enabledBy.name }} ||{{/ if }} (row.__deleteable !== undefined && !row.__deleteable),
+                {{ else }}
+                    action: async (row: {{ classDataName table.dataElement.target 'Stored' }}) => {{ actionFunctionName action }}({{# if (hasDataElementOwner action.dataElement) }}ownerData, {{/ if }}row, () => fetchOwnerData()),
+                    disabled: (row: {{ classDataName table.dataElement.target 'Stored' }}) => {{# if table.enabledBy }}!ownerData.{{ table.enabledBy.name }} ||{{/ if }} editMode || !row.__deleteable,
+                {{/ if }}
             },
         {{/ if }}
         {{# if action.isCallOperationAction }}

--- a/judo-ui-react/src/main/resources/actor/src/pages/access/table/page-actions.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/access/table/page-actions.hbs
@@ -18,6 +18,7 @@ export interface PageActionsProps {
 export function PageActions (props: PageActionsProps) {
     const { isLoading, fetchData } = props;
     const { t } = useTranslation();
+    const editMode = false;
 
     {{# each (getOnlyPageActions page) as |action| }}
         {{# unless action.isFilterAction }}
@@ -30,7 +31,7 @@ export function PageActions (props: PageActionsProps) {
             {{# each (getUniquePageActions page) as |action| }}
                 {{# if action.isCreateAction }}
                     <Grid className="page-action" item>
-                        <Button id="page-action-create" startIcon={<MdiIcon path="file_document_plus" />} onClick={ () => {{ actionFunctionName action }}(() => fetchData()) } disabled={isLoading}>
+                        <Button id="page-action-create" startIcon={<MdiIcon path="file_document_plus" />} onClick={ () => {{ actionFunctionName action }}(editMode, () => fetchData()) } disabled={isLoading}>
                             {t('judo.pages.table.create', { defaultValue: 'Create' })}
                         </Button>
                     </Grid>

--- a/judo-ui-react/src/main/resources/actor/src/pages/actions/action/create-action.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/actions/action/create-action.tsx.hbs
@@ -38,6 +38,7 @@ import { {{ pageActionFormComponentName action }} } from './{{ pageActionFormCom
 
 export type {{ actionFunctionTypeName action }} = () => (
   {{# unless (isActionAccess action) }}owner: JudoIdentifiable<{{ classDataName action.dataElement.target '' }}>,{{/ unless }}
+  callerEditMode: boolean,
   successCallback: (result: {{ classDataName action.dataElement.target 'Stored' }}) => void,
   closedCallback?: () => void,
 ) => void;
@@ -51,7 +52,7 @@ export const {{ actionFunctionHookName action }}: {{ actionFunctionTypeName acti
     {{/ unless }}
     const { enqueueSnackbar } = useSnackbar();
 
-    return function {{ actionFunctionName action }} ({{# unless (isActionAccess action) }}owner: JudoIdentifiable<{{ classDataName action.dataElement.target '' }}>,{{/ unless }}successCallback: (result: {{ classDataName action.dataElement.target 'Stored' }}) => void, closedCallback?: () => void) {
+    return function {{ actionFunctionName action }} ({{# unless (isActionAccess action) }}owner: JudoIdentifiable<{{ classDataName action.dataElement.target '' }}>,{{/ unless }}callerEditMode: boolean, successCallback: (result: {{ classDataName action.dataElement.target 'Stored' }}) => void, closedCallback?: () => void) {
         {{# if (actionHasVisualElements action) }}
             createDialog({
                 {{# if action.target.dialogSize }}
@@ -66,13 +67,16 @@ export const {{ actionFunctionHookName action }}: {{ actionFunctionTypeName acti
                 },
                 children: (
                     <{{ pageActionFormComponentName action }}
+                        callerEditMode={callerEditMode}
                         successCallback={(result: {{ classDataName action.dataElement.target 'Stored' }}, open?: boolean) => {
                             if(!open) {
-                              closeDialog();
-                              enqueueSnackbar(t('judo.action.create.success', { defaultValue: 'Create successful' }), {
-                                  variant: 'success',
-                                  ...toastConfig.success,
-                              });
+                                closeDialog();
+                                if (!callerEditMode) {
+                                    enqueueSnackbar(t('judo.action.create.success', { defaultValue: 'Create successful' }), {
+                                        variant: 'success',
+                                        ...toastConfig.success,
+                                    });
+                                }
                             }
 
                             successCallback(result);

--- a/judo-ui-react/src/main/resources/actor/src/pages/actions/actionForm/components/link.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/actions/actionForm/components/link.tsx.hbs
@@ -73,6 +73,11 @@ export function {{ linkComponentName link }}(props: {{ linkComponentName link }}
                 storeDiff('{{ link.dataElement.name }}', {{ link.dataElement.name }});
             } }
             {{# each link.actions as |action| }}
+                {{# if action.isCreateAction }}
+                    onCreate={ async () => {{ actionFunctionName action }}({{# unless (isActionAccess action) }}ownerData, {{/ unless }}editMode, (result: {{ classDataName action.dataElement.target 'Stored' }}) => {
+                        storeDiff('{{ link.dataElement.name }}', result);
+                    }) }
+                {{/ if }}
                 {{# if action.isRemoveAction }}
                     onRemove={ async () => {
                         storeDiff('{{ link.dataElement.name }}', null);

--- a/judo-ui-react/src/main/resources/actor/src/pages/actions/actionForm/createActionForm.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/actions/actionForm/createActionForm.tsx.hbs
@@ -32,6 +32,7 @@ import {
 {{/ each }}
 
 export interface {{ pageActionFormComponentName action }}Props {
+    callerEditMode?: boolean;
     successCallback: (result: {{ classDataName page.dataElement.target 'Stored' }}, open?: boolean) => void;
     cancel: () => void;
     {{# if (hasDataElementOwner action.dataElement) }}
@@ -40,6 +41,7 @@ export interface {{ pageActionFormComponentName action }}Props {
 }
 
 export function {{ pageActionFormComponentName action }}({
+    callerEditMode,
     successCallback,
     cancel,
     {{# if (hasDataElementOwner action.dataElement) }}
@@ -104,9 +106,16 @@ export function {{ pageActionFormComponentName action }}({
         setIsLoading(true);
 
         try {
-            const res = await {{ dataElementRelationName page.dataElement }}Impl.create{{ ucFirst page.dataElement.name }}({{# if (hasDataElementOwner action.dataElement) }}owner, {{/ if }}payloadDiff);
-
-            return res;
+            if (!callerEditMode) {
+                // only call backend if the create dialog has been triggered on a View Page
+                return await {{ dataElementRelationName page.dataElement }}Impl.create{{ ucFirst page.dataElement.name }}({{# if (hasDataElementOwner action.dataElement) }}owner, {{/ if }}payloadDiff);
+            } else {
+                // add temp identifier in order to counter mui key errors in tables, the `storeDiff` function should take care of it.
+                return {
+                    ...payloadDiff,
+                    __identifier: `JUDO_TMP_${new Date()}`,
+                } as {{ classDataName page.dataElement.target 'Stored' }};
+            }
         } catch (error) {
             handleCreateError(error, { setValidation }, data);
         } finally {
@@ -181,30 +190,33 @@ export function {{ pageActionFormComponentName action }}({
 
                                                 if (result) {
                                                     successCallback(result);
-                                                    {{# unless (pageShouldOpenInDialog (getViewPageForCreatePage page application)) }}
-                                                        navigate(routeTo{{ pageName (getViewPageForCreatePage page application) }}(result.__signedIdentifier));
-                                                    {{ else }}
-                                                        createDialog({
-                                                            {{# if (adjustDialogSize (getViewPageForCreatePage page application)) }}
-                                                                fullWidth: true,
-                                                                maxWidth: '{{ getDialogSizeForViewPageOfCreatePage page application }}',
-                                                            {{/ if }}
-                                                            onClose: (event: object, reason: string) => {
-                                                                if (reason !== 'backdropClick') {
-                                                                    closeDialog();
-                                                                }
-                                                            },
-                                                            children: (
-                                                                <{{ pageName (getViewPageForCreatePage page application) }}
-                                                                    successCallback={ () => {
-                                                                        successCallback(result, true);
-                                                                    } }
-                                                                    cancel={closeDialog}
-                                                                    entry={result}
-                                                                />
-                                                            ),
-                                                        });
-                                                    {{/ unless }}
+                                                    if (!callerEditMode) {
+                                                        // only trigger followup behaviors if action was initiated on a View Page and not in editMode
+                                                        {{# unless (pageShouldOpenInDialog (getViewPageForCreatePage page application)) }}
+                                                            navigate(routeTo{{ pageName (getViewPageForCreatePage page application) }}(result.__signedIdentifier));
+                                                        {{ else }}
+                                                            createDialog({
+                                                                {{# if (adjustDialogSize (getViewPageForCreatePage page application)) }}
+                                                                    fullWidth: true,
+                                                                    maxWidth: '{{ getDialogSizeForViewPageOfCreatePage page application }}',
+                                                                {{/ if }}
+                                                                onClose: (event: object, reason: string) => {
+                                                                    if (reason !== 'backdropClick') {
+                                                                        closeDialog();
+                                                                    }
+                                                                },
+                                                                children: (
+                                                                    <{{ pageName (getViewPageForCreatePage page application) }}
+                                                                        successCallback={ () => {
+                                                                            successCallback(result, true);
+                                                                        } }
+                                                                        cancel={closeDialog}
+                                                                        entry={result}
+                                                                    />
+                                                                ),
+                                                            });
+                                                        {{/ unless }}
+                                                    }
                                                 }
                                             } } disabled={isLoading}>
                                                 {t('judo.pages.create-and-navigate', { defaultValue: 'Create and navigate' })}

--- a/judo-ui-react/src/main/resources/actor/src/pages/components/link.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/components/link.tsx.hbs
@@ -84,8 +84,12 @@ export function {{ linkComponentName link }}(props: {{ linkComponentName link }}
                     onView={ async () => {{ actionFunctionName action }}(ownerData, ownerData?.{{ link.dataElement.name }}!, () => fetchOwnerData()) }
                 {{/ if }}
                 {{# if action.isCreateAction }}
-                    onCreate={ async () => {{ actionFunctionName action }}({{# unless (isActionAccess action) }}ownerData, {{/ unless }}() => {
-                        fetchOwnerData();
+                    onCreate={ async () => {{ actionFunctionName action }}({{# unless (isActionAccess action) }}ownerData, {{/ unless }}editMode, (result: {{ classDataName action.dataElement.target 'Stored' }}) => {
+                        if (!editMode) {
+                            fetchOwnerData();
+                        } else {
+                            storeDiff('{{ link.dataElement.name }}', result);
+                        }
                     }) }
                 {{/ if }}
                 {{# if action.isDeleteAction }}
@@ -117,7 +121,7 @@ export function {{ linkComponentName link }}(props: {{ linkComponentName link }}
                                 // we do not allow creation in such cases.
                                 createTrigger: !ownerData.{{ link.dataElement.name }} ? async () => {
                                     return new Promise((resolve) => {
-                                        {{ actionFunctionName (getCreateActionForLink link) }}({{# unless (isActionAccess action) }}ownerData, {{/ unless }}(result: {{ classDataName link.dataElement.target 'Stored' }}) => {
+                                        {{ actionFunctionName (getCreateActionForLink link) }}({{# unless (isActionAccess action) }}ownerData, {{/ unless }}editMode, (result: {{ classDataName link.dataElement.target 'Stored' }}) => {
                                             resolve(result);
                                         }, () => {
                                             resolve(undefined);

--- a/judo-ui-react/src/main/resources/actor/src/pages/components/table/for-aggregation.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/components/table/for-aggregation.hbs
@@ -188,11 +188,15 @@ export const {{ tableComponentName table }} = (props: {{ tableComponentName tabl
                                             id="{{ createId action }}"
                                             startIcon={<MdiIcon path="file_document_plus" />}
                                             variant="text"
-                                            onClick={() => {{ actionFunctionName action }}({{# unless (isActionAccess action) }}ownerData, {{/ unless }}() => {
-                                                fetchOwnerData();
+                                            onClick={() => {{ actionFunctionName action }}({{# unless (isActionAccess action) }}ownerData, {{/ unless }}editMode, (result: {{ classDataName action.dataElement.target 'Stored' }}) => {
+                                                if (!editMode) {
+                                                    fetchOwnerData();
+                                                } else {
+                                                    storeDiff('{{ table.dataElement.name }}', [...(ownerData.{{ table.dataElement.name }} || []), result]);
+                                                }
                                             })}
                                             disabled={
-                                                   editMode
+                                                   {{# if table.dataElement.isRelationKindComposition }}false{{ else }}editMode{{/ if }}
                                                 || isOwnerLoading
                                                 || {{# if table.enabledBy }}!ownerData.{{ table.enabledBy.name }} ||{{/ if }} {{ boolValue table.dataElement.isReadOnly }}
                                                 || !isFormUpdateable()

--- a/judo-ui-react/src/main/resources/actor/src/pages/relation/table/page-actions.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/relation/table/page-actions.hbs
@@ -24,6 +24,7 @@ export interface PageActionsProps {
 export function PageActions (props: PageActionsProps) {
     const { isLoading, fetchData, signedIdentifier } = props;
     const { t } = useTranslation();
+    const editMode = false;
 
     {{# each (getOnlyPageActions page) as |action| }}
         {{# unless action.isFilterAction }}
@@ -58,7 +59,7 @@ export function PageActions (props: PageActionsProps) {
                     {{/ if }}
                     {{# if action.isCreateAction }}
                         <Grid className="page-action" item>
-                            <Button id="page-action-create" startIcon={<MdiIcon path="file_document_plus" />} onClick={ () => {{ actionFunctionName action }}({ __signedIdentifier: signedIdentifier } as JudoIdentifiable<{{ classDataName table.dataElement.owner '' }}>, () => fetchData()) } disabled={isLoading}>
+                            <Button id="page-action-create" startIcon={<MdiIcon path="file_document_plus" />} onClick={ () => {{ actionFunctionName action }}({ __signedIdentifier: signedIdentifier } as JudoIdentifiable<{{ classDataName table.dataElement.owner '' }}>, editMode, () => fetchData()) } disabled={isLoading}>
                                 {t('judo.pages.table.create', { defaultValue: 'Create' })}
                             </Button>
                         </Grid>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5152" title="JNG-5152" target="_blank"><img alt="Story" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />JNG-5152</a>  Support relation CRUD with container create/update on UI
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Ticket will have multiple PR-s, this is the first one.

No transaction has been hurt in the making of this change!

Changes:

**Enabled Composition list create action in edit mode. Could work for create-in-create, couldn't test, but works on View**

![create-composition-mid-edit](https://github.com/BlackBeltTechnology/judo-ui-react-template/assets/1084847/0570c35b-f72a-4e27-8ec7-5b58f1b69cf3)


**Enabled Composition list delete action in edit mode. Even for newly created, "transient" elements.**

![delete-composition-in-edit](https://github.com/BlackBeltTechnology/judo-ui-react-template/assets/1084847/30f384ce-c4a2-4237-8bdd-f5a7aa7c2162)
