### PR TITLE
JNG-5160 fix association table lifecycle

### DIFF
--- a/judo-ui-react/src/main/resources/actor/src/pages/components/table/for-association.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/components/table/for-association.hbs
@@ -304,7 +304,7 @@ export const {{ tableComponentName table }} = forwardRef<RefreshableTable, {{ ta
                                         id="{{ createId action }}"
                                         startIcon={<MdiIcon path="file_document_plus" />}
                                         variant="text"
-                                        onClick={ () => {{ actionFunctionName action }}(ownerData, () => fetchData()) }
+                                        onClick={ () => {{ actionFunctionName action }}(ownerData, () => fetchOwnerData()) }
                                         disabled={
                                                editMode
                                             || isLoading
@@ -321,7 +321,7 @@ export const {{ tableComponentName table }} = forwardRef<RefreshableTable, {{ ta
                                         startIcon={<MdiIcon path="attachment-plus" />}
                                         variant="text"
                                         onClick={ async () => {
-                                            {{ actionFunctionName action }}(ownerData, () => fetchData())
+                                            {{ actionFunctionName action }}(ownerData, () => fetchOwnerData())
                                         } }
                                         disabled={ {{# if table.enabledBy }}!ownerData.{{ table.enabledBy.name }} ||{{/ if }} isLoading }
                                     >
@@ -334,7 +334,7 @@ export const {{ tableComponentName table }} = forwardRef<RefreshableTable, {{ ta
                                         startIcon={<MdiIcon path="link_off" />}
                                         variant="text"
                                         onClick={ async () => {
-                                            {{ actionFunctionName action }}(ownerData, () => fetchData())
+                                            {{ actionFunctionName action }}(ownerData, () => fetchOwnerData())
                                         } }
                                         disabled={ {{# if table.enabledBy }}!ownerData.{{ table.enabledBy.name }} ||{{/ if }} isLoading }
                                     >


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5160" title="JNG-5160" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-5160</a>  Create on mapping association with table representation does not trigger refresh on main view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Technically it was nothing wrong with it, wasn't prepared to handle the fact that since we have interceptors, anything can change...