### PR TITLE
JNG-4881 react hotkeys

### DIFF
--- a/docs/pages/01_ui_react.adoc
+++ b/docs/pages/01_ui_react.adoc
@@ -775,11 +775,11 @@ export const registerGlobalHotkeys = () => {
 
   // wire in hotkeys
   useHotkeys(CREATE_GALAXY, () => {
-    pageCreateGalaxiesAction(() => { // noop });
+    pageCreateGalaxiesAction(() => { /* noop */ });
   });
 
   useHotkeys(CREATE_MATTER, () => {
-    pageCreateMatterAction(() => { // noop });
+    pageCreateMatterAction(() => { /* noop */ });
   });
 
   /**

--- a/docs/pages/01_ui_react.adoc
+++ b/docs/pages/01_ui_react.adoc
@@ -738,3 +738,95 @@ const customGodCreateNameOnBlurHook: GodCreateNameOnBlurHook = () => {
   };
 };
 ----
+
+=== (Global) Hotkey support
+
+Currently you can wire in hotkeys for access-based actions, such as triggering create dialogs.
+
+The generated file can be located at `src/hotkeys.tsx`.
+
+This file **MUST** export a React hook called `registerGlobalHotkeys`!
+
+Parts of this file can be "implemented" bia fragment overrides, but a complete example can be found here:
+
+*src/hotkeys.tsx:*
+[source,typescriptjsx]
+----
+import { useHotkeys } from 'react-hotkeys-hook';
+import { useTranslation } from 'react-i18next';
+import { Button, Chip, DialogActions, DialogContent, DialogTitle, Grid, List, ListItem, ListItemText } from '@mui/material';
+import { useDialog } from '~/components/dialog';
+import { MdiIcon } from '~/components';
+import { usePageCreateGalaxiesAction } from './pages/god/galaxies/table/actions/pageCreateGalaxies';
+import { usePageCreateMatterAction } from './pages/god/matter/table/actions/pageCreateMatter';
+
+export const registerGlobalHotkeys = () => {
+  const { t } = useTranslation();
+  const [createDialog, closeDialog] = useDialog();
+
+  // get hooks
+  const pageCreateGalaxiesAction = usePageCreateGalaxiesAction();
+  const pageCreateMatterAction = usePageCreateMatterAction();
+
+  // define hotkeys
+  const KOTKEY_DIALOG = 'Ctrl + Space';
+  const CREATE_GALAXY = 'Ctrl + G';
+  const CREATE_MATTER = 'Ctrl + M';
+
+  // wire in hotkeys
+  useHotkeys(CREATE_GALAXY, () => {
+    pageCreateGalaxiesAction(() => { // noop });
+  });
+
+  useHotkeys(CREATE_MATTER, () => {
+    pageCreateMatterAction(() => { // noop });
+  });
+
+  /**
+   * This section is optional! It is only a dialog listing every hotkey.
+   */
+  useHotkeys(KOTKEY_DIALOG, () => {
+    createDialog({
+      fullWidth: true,
+      maxWidth: 'sm',
+      onClose: (event: object, reason: string) => {
+        if (reason !== 'backdropClick') {
+          closeDialog();
+        }
+      },
+      children: (
+        <>
+          <DialogTitle>
+            {t('judo.hotkeys.dialog.title', { defaultValue: 'List of Hotkeys' }) as string}
+          </DialogTitle>
+          <DialogContent dividers>
+            <Grid container spacing={2} direction="row" alignItems="stretch" justifyContent="flex-start">
+              <List>
+                <ListItem>
+                  <Chip label={CREATE_GALAXY} variant="outlined" sx={{ mr: 2 }} />
+                  <ListItemText id="trigger-create-galaxy" primary={t('judo.hotkeys.create-galaxy.label', { defaultValue: 'Create Galaxy' }) as string} />
+                </ListItem>
+                <ListItem>
+                  <Chip label={CREATE_MATTER} variant="outlined" sx={{ mr: 2 }} />
+                  <ListItemText id="trigger-create-matter" primary={t('judo.hotkeys.create-matter.label', { defaultValue: 'Create Matter' }) as string} />
+                </ListItem>
+              </List>
+            </Grid>
+          </DialogContent>
+          <DialogActions>
+            <Button
+              id="judo-close-hotkeys"
+              variant="text"
+              onClick={() => closeDialog()}
+              startIcon={<MdiIcon path="close-thick" />}
+            >
+              {t('judo.modal.close', { defaultValue: 'Close' }) as string}
+            </Button>
+          </DialogActions>
+        </>
+      ),
+    });
+  });
+};
+
+----

--- a/judo-ui-react/src/main/resources/actor/package.json.dependencies.fragment.hbs
+++ b/judo-ui-react/src/main/resources/actor/package.json.dependencies.fragment.hbs
@@ -21,6 +21,7 @@
 "oidc-client-ts": "2.2.1",
 "react": "18.2.0",
 "react-dom": "18.2.0",
+"react-hotkeys-hook": "4.4.1",
 "react-i18next": "12.1.1",
 "react-number-format": "5.3.0",
 "react-oidc-context": "2.2.1",

--- a/judo-ui-react/src/main/resources/actor/pnpm-lock.pro.yaml
+++ b/judo-ui-react/src/main/resources/actor/pnpm-lock.pro.yaml
@@ -70,6 +70,9 @@ dependencies:
   react-dom:
     specifier: 18.2.0
     version: 18.2.0(react@18.2.0)
+  react-hotkeys-hook:
+    specifier: 4.4.1
+    version: 4.4.1(react-dom@18.2.0)(react@18.2.0)
   react-i18next:
     specifier: 12.1.1
     version: 12.1.1(i18next@22.4.6)(react-dom@18.2.0)(react@18.2.0)
@@ -2034,6 +2037,16 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
+    dev: false
+
+  /react-hotkeys-hook@4.4.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-sClBMBioFEgFGYLTWWRKvhxcCx1DRznd+wkFHwQZspnRBkHTgruKIHptlK/U/2DPX8BhHoRGzpMVWUXMmdZlmw==}
+    peerDependencies:
+      react: '>=16.8.1'
+      react-dom: '>=16.8.1'
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /react-i18next@12.1.1(i18next@22.4.6)(react-dom@18.2.0)(react@18.2.0):

--- a/judo-ui-react/src/main/resources/actor/pnpm-lock.yaml
+++ b/judo-ui-react/src/main/resources/actor/pnpm-lock.yaml
@@ -67,6 +67,9 @@ dependencies:
   react-dom:
     specifier: 18.2.0
     version: 18.2.0(react@18.2.0)
+  react-hotkeys-hook:
+    specifier: 4.4.1
+    version: 4.4.1(react-dom@18.2.0)(react@18.2.0)
   react-i18next:
     specifier: 12.1.1
     version: 12.1.1(i18next@22.4.6)(react-dom@18.2.0)(react@18.2.0)
@@ -1993,6 +1996,16 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
+    dev: false
+
+  /react-hotkeys-hook@4.4.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-sClBMBioFEgFGYLTWWRKvhxcCx1DRznd+wkFHwQZspnRBkHTgruKIHptlK/U/2DPX8BhHoRGzpMVWUXMmdZlmw==}
+    peerDependencies:
+      react: '>=16.8.1'
+      react-dom: '>=16.8.1'
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /react-i18next@12.1.1(i18next@22.4.6)(react-dom@18.2.0)(react@18.2.0):

--- a/judo-ui-react/src/main/resources/actor/src/components/dialog/hooks.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/dialog/hooks.tsx.hbs
@@ -30,7 +30,7 @@ export const usePageDialog = () => {
   const context = useContext(PageDialogContextState);
 
   if (context === undefined) {
-    throw new Error('useConfirmDialog was used outside its Provider');
+    throw new Error('usePageDialog was used outside its Provider');
   }
 
   return context;

--- a/judo-ui-react/src/main/resources/actor/src/hotkeys.tsx.body.fragment.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/hotkeys.tsx.body.fragment.hbs
@@ -1,0 +1,1 @@
+// To implement / add hotkeys you can override the `actor/src/hotkeys.tsx.body.fragment.hbs` file.

--- a/judo-ui-react/src/main/resources/actor/src/hotkeys.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/hotkeys.tsx.hbs
@@ -1,7 +1,6 @@
 import { useHotkeys } from 'react-hotkeys-hook';
 import { useTranslation } from 'react-i18next';
 import { useDialog } from '~/components/dialog';
-import { MdiIcon } from '~/components';
 {{> actor/src/hotkeys.tsx.imports.fragment.hbs }}
 
 export const registerGlobalHotkeys = () => {

--- a/judo-ui-react/src/main/resources/actor/src/hotkeys.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/hotkeys.tsx.hbs
@@ -1,0 +1,12 @@
+import { useHotkeys } from 'react-hotkeys-hook';
+import { useTranslation } from 'react-i18next';
+import { useDialog } from '~/components/dialog';
+import { MdiIcon } from '~/components';
+{{> actor/src/hotkeys.tsx.imports.fragment.hbs }}
+
+export const registerGlobalHotkeys = () => {
+  const { t } = useTranslation();
+  const [createDialog, closeDialog] = useDialog();
+
+  {{> actor/src/hotkeys.tsx.body.fragment.hbs }}
+};

--- a/judo-ui-react/src/main/resources/actor/src/hotkeys.tsx.imports.fragment.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/hotkeys.tsx.imports.fragment.hbs
@@ -1,0 +1,1 @@
+// To import your actions and extra stuff here you can override the `actor/src/hotkeys.tsx.imports.fragment.hbs` file.

--- a/judo-ui-react/src/main/resources/actor/src/layout/Layout.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/layout/Layout.tsx.hbs
@@ -9,6 +9,7 @@ import { MenuItem } from '../components-api';
 import { Navigator } from './Navigator';
 import { Footer } from './Footer';
 import { Header } from './Header';
+import { registerGlobalHotkeys } from '../hotkeys';
 
 export interface LayoutProps {
   items: Array<MenuItem>;
@@ -20,6 +21,7 @@ export interface LayoutProps {
 export function Layout({ items, drawerWidth, hero, logo }: LayoutProps) {
   const [mobileOpen, setMobileOpen] = useState<boolean>(false);
   const isSmUp = useMediaQuery(theme.breakpoints.up('sm'));
+  registerGlobalHotkeys();
 
   const handleDrawerToggle = () => {
     setMobileOpen(!mobileOpen);

--- a/judo-ui-react/src/main/resources/ui-react.yaml
+++ b/judo-ui-react/src/main/resources/ui-react.yaml
@@ -179,6 +179,10 @@ templates:
     pathExpression: "'src/App.tsx'"
     templateName: actor/src/App.tsx.hbs
 
+  - name: actor/src/hotkeys.tsx
+    pathExpression: "'src/hotkeys.tsx'"
+    templateName: actor/src/hotkeys.tsx.hbs
+
   - name: actor/src/menu-items.tsx
     pathExpression: "'src/menu-items.tsx'"
     templateName: actor/src/menu-items.tsx.hbs


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-4881" title="JNG-4881" target="_blank"><img alt="Story" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />JNG-4881</a>  Add hotkey support for React frontends
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


**src/hotkeys.tsx:**

```typescript
import { useHotkeys } from 'react-hotkeys-hook';
import { useTranslation } from 'react-i18next';
import { Button, Chip, DialogActions, DialogContent, DialogTitle, Grid, List, ListItem, ListItemText } from '@mui/material';
import { useDialog } from '~/components/dialog';
import { MdiIcon } from '~/components';
import { usePageCreateGalaxiesAction } from './pages/god/galaxies/table/actions/pageCreateGalaxies';
import { usePageCreateMatterAction } from './pages/god/matter/table/actions/pageCreateMatter';

export const registerGlobalHotkeys = () => {
  const { t } = useTranslation();
  const [createDialog, closeDialog] = useDialog();

  // get hooks
  const pageCreateGalaxiesAction = usePageCreateGalaxiesAction();
  const pageCreateMatterAction = usePageCreateMatterAction();

  // define hotkeys
  const KOTKEY_DIALOG = 'Ctrl + Space';
  const CREATE_GALAXY = 'Ctrl + G';
  const CREATE_MATTER = 'Ctrl + M';

  // wire in hotkeys
  useHotkeys(CREATE_GALAXY, () => {
    pageCreateGalaxiesAction(() => { /* noop */ });
  });

  useHotkeys(CREATE_MATTER, () => {
    pageCreateMatterAction(() => { /* noop */ });
  });

  /**
   * This section is optional! It is only a dialog listing every hotkey.
   */
  useHotkeys(KOTKEY_DIALOG, () => {
    createDialog({
      fullWidth: true,
      maxWidth: 'sm',
      onClose: (event: object, reason: string) => {
        if (reason !== 'backdropClick') {
          closeDialog();
        }
      },
      children: (
        <>
          <DialogTitle>
            {t('judo.hotkeys.dialog.title', { defaultValue: 'List of Hotkeys' }) as string}
          </DialogTitle>
          <DialogContent dividers>
            <Grid container spacing={2} direction="row" alignItems="stretch" justifyContent="flex-start">
              <List>
                <ListItem>
                  <Chip label={CREATE_GALAXY} variant="outlined" sx={{ mr: 2 }} />
                  <ListItemText id="trigger-create-galaxy" primary={t('judo.hotkeys.create-galaxy.label', { defaultValue: 'Create Galaxy' }) as string} />
                </ListItem>
                <ListItem>
                  <Chip label={CREATE_MATTER} variant="outlined" sx={{ mr: 2 }} />
                  <ListItemText id="trigger-create-matter" primary={t('judo.hotkeys.create-matter.label', { defaultValue: 'Create Matter' }) as string} />
                </ListItem>
              </List>
            </Grid>
          </DialogContent>
          <DialogActions>
            <Button
              id="judo-close-hotkeys"
              variant="text"
              onClick={() => closeDialog()}
              startIcon={<MdiIcon path="close-thick" />}
            >
              {t('judo.modal.close', { defaultValue: 'Close' }) as string}
            </Button>
          </DialogActions>
        </>
      ),
    });
  });
};
```