### PR TITLE
JNG-5229 When there are hidden tabs, the other tabs shift

### DIFF
--- a/judo-ui-react/src/main/resources/actor/src/components/ModeledTabs.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/ModeledTabs.tsx.hbs
@@ -92,11 +92,11 @@ export function ModeledTabs({ id, ownerData, childTabs, children, orientation, v
                 indicatorColor="secondary"
                 sx={ { [border]: 1, borderColor: 'divider' } }
             >
-                {childTabs.filter(c => !c.hidden).map((c: any, index: number) => (
-                <Tab className={hasNestedError(c) ? 'JUDO-nestedError' : undefined} id={`${c.id}-tab`} key={c.id} label={c.label} icon={c.icon ? <MdiIcon path={c.icon} sx={ { m: '0 0.5rem' } } /> : '' } iconPosition="start" disabled={c.disabled} />
+                {childTabs.map((c: any, index: number) => (
+                <Tab className={hasNestedError(c) ? 'JUDO-nestedError' : undefined} id={`${c.id}-tab`} key={c.id} label={c.label} icon={c.icon ? <MdiIcon path={c.icon} sx={ { m: '0 0.5rem' } } /> : '' } iconPosition="start" disabled={c.disabled} style={ { display:  c.hidden ? 'none' : undefined, } } />
                 ))}
             </Tabs>
-            {childTabs.filter(c => !c.hidden).map((c: any, index: number) => (
+            {childTabs.map((c: any, index: number) => (
                 <TabPanel id={`${c.id}-tab-panel`} key={c.id} value={value} index={index}>
                     {Array.isArray(children) ? children[index] : ''}
                 </TabPanel>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5229" title="JNG-5229" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-5229</a>  Tab handling content area wrong when enabledBy is used
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
