### PR TITLE
JNG-5313 fix delete confirmation dialog appears twice after deletion

### DIFF
--- a/judo-ui-react/src/main/resources/actor/src/containers/dialog.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/dialog.tsx.hbs
@@ -163,15 +163,7 @@ export default function {{ containerComponentName container }}Dialog(props: {{ c
                   {{/ if }}
                   onClick={ async () => {
                     {{# if button.actionDefinition.isDeleteAction }}
-                      const confirmed = await openConfirmDialog(
-                        'page-delete-action',
-                        t('judo.modal.confirm.confirm-delete', { defaultValue: 'Are you sure you would like to delete the selected element?' }),
-                        t('judo.modal.confirm.confirm-title', { defaultValue: 'Confirm action' }),
-                      );
-
-                      if (confirmed) {
-                        actions.{{ simpleActionDefinitionName actionDefinition }}!();
-                      }
+                      actions.{{ simpleActionDefinitionName actionDefinition }}!();
                     {{ else }}
                       {{# if actionDefinition.isRefreshAction }}
                         await actions.{{ simpleActionDefinitionName actionDefinition }}!(processQueryCustomizer(queryCustomizer));

--- a/judo-ui-react/src/main/resources/actor/src/containers/page.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/page.tsx.hbs
@@ -87,15 +87,7 @@ export default function {{ containerComponentName container }}Page (props: {{ co
                   {{/ if }}
                   onClick={ async () => {
                     {{# if button.actionDefinition.isDeleteAction }}
-                      const confirmed = await openConfirmDialog(
-                        'page-delete-action',
-                        t('judo.modal.confirm.confirm-delete', { defaultValue: 'Are you sure you would like to delete the selected element?' }),
-                        t('judo.modal.confirm.confirm-title', { defaultValue: 'Confirm action' }),
-                      );
-
-                      if (confirmed) {
                         actions.{{ simpleActionDefinitionName actionDefinition }}!();
-                      }
                     {{ else }}
                       {{# if actionDefinition.isRefreshAction }}
                         await actions.{{ simpleActionDefinitionName actionDefinition }}!(processQueryCustomizer(queryCustomizer));

--- a/judo-ui-react/src/main/resources/actor/src/containers/page.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/page.tsx.hbs
@@ -87,7 +87,7 @@ export default function {{ containerComponentName container }}Page (props: {{ co
                   {{/ if }}
                   onClick={ async () => {
                     {{# if button.actionDefinition.isDeleteAction }}
-                        actions.{{ simpleActionDefinitionName actionDefinition }}!();
+                      actions.{{ simpleActionDefinitionName actionDefinition }}!();
                     {{ else }}
                       {{# if actionDefinition.isRefreshAction }}
                         await actions.{{ simpleActionDefinitionName actionDefinition }}!(processQueryCustomizer(queryCustomizer));


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5313" title="JNG-5313" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-5313</a>  The Delete confirmation dialog appears twice after deletion on Access View Page.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

https://github.com/BlackBeltTechnology/judo-ui-react-template/assets/119794838/dcc26dc6-708a-42cd-9f1d-bfc427961891

