### PR TITLE
JNG-5350 streamline confirm dialogs

### DIFF
--- a/judo-ui-react/src/main/resources/actor/src/containers/components/table.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/components/table.tsx.hbs
@@ -37,6 +37,7 @@ import {
   ContextMenu,
   StripedDataGrid,
 } from '~/components/table';
+import { useConfirmDialog } from '~/components/dialog';
 import type { ContextMenuApi } from '~/components/table/ContextMenu';
 import type { Filter, FilterOption } from '~/components-api';
 import { FilterType } from '~/components-api';
@@ -153,6 +154,7 @@ export function {{ componentName table }}(props: {{ componentName table }}Props)
   const filterModelKey = `{{ createId table }}-${uniqueId}-filterModel`;
   const filtersKey = `{{ createId table }}-${uniqueId}-filters`;
 
+  const { openConfirmDialog } = useConfirmDialog();
   const { getItemParsed, getItemParsedWithDefault, setItemStringified } = useDataStore('sessionStorage');
   {{# or (tableHasNumericColumn table) (tableHasDateColumn table) (tableHasDateTimeColumn table) }}
   const { locale: l10nLocale } = useL10N();
@@ -254,8 +256,11 @@ export function {{ componentName table }}(props: {{ componentName table }}Props)
       disabled: (row: {{ classDataName (getReferenceClassType table) 'Stored' }}) => {{{ tableRowButtonDisabledConditions button table container }}},
       action: actions.{{ simpleActionDefinitionName button.actionDefinition }} ? async (rowData) => {
         {{# if button.confirmation }}
-          // TODO: implement shiny MUI Dialog here
-          const result = confirm(t('{{ getTranslationKeyForVisualElement button }}.confirmation', { defaultValue: '{{ button.confirmation.confirmationMessage }}' }) as string);
+          const result = await openConfirmDialog(
+            '{{ getXMIID button }}',
+            t('{{ getTranslationKeyForVisualElement button }}.confirmation', { defaultValue: '{{ button.confirmation.confirmationMessage }}' }) as string,
+            t('judo.modal.confirm.confirm-title', { defaultValue: 'Confirm action' }) as string,
+          );
 
           if (!result) {
             return;

--- a/judo-ui-react/src/main/resources/actor/src/containers/container.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/container.tsx.hbs
@@ -67,6 +67,7 @@ export default function {{ containerComponentName container }}(props: {{ contain
     const { navigate, back } = useJudoNavigation();
     const { refreshCounter, actions{{# if container.isSelector }}, selectionDiff, setSelectionDiff{{/ if }}{{# if container.isRelationSelector }}, alreadySelected{{/ if }}{{# unless container.table }}, data, isLoading, isFormUpdateable, isFormDeleteable, storeDiff, editMode, validation, setValidation, submit{{/ unless }} } = props;
     const { locale: l10nLocale } = useL10N();
+    const { openConfirmDialog } = useConfirmDialog();
 
     {{# unless container.table }}
       useConfirmationBeforeChange(editMode, t('judo.form.navigation.confirmation', { defaultValue: 'You have potential unsaved changes in your form, are you sure you would like to navigate away?' }));

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/buttongroup.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/buttongroup.hbs
@@ -22,8 +22,11 @@
           {{/ if }}
           onClick={ actions.{{ simpleActionDefinitionName button.actionDefinition }} ? async () => {
             {{# if button.confirmation }}
-              // TODO: implement shiny MUI Dialog here
-              const result = confirm(t('{{ getTranslationKeyForVisualElement button }}.confirmation', { defaultValue: '{{ button.confirmation.confirmationMessage }}' }) as string);
+              const result = await openConfirmDialog(
+                '{{ getXMIID button }}',
+                t('{{ getTranslationKeyForVisualElement button }}.confirmation', { defaultValue: '{{ button.confirmation.confirmationMessage }}' }) as string,
+                t('judo.modal.confirm.confirm-title', { defaultValue: 'Confirm action' }) as string,
+              );
 
               if (!result) {
                 return;
@@ -53,8 +56,11 @@
                 label: t('{{ getTranslationKeyForVisualElement button }}', { defaultValue: '{{ button.label }}' }) as string,
                 onClick: actions.{{ simpleActionDefinitionName button.actionDefinition }} ? async () => {
                   {{# if button.confirmation }}
-                    // TODO: implement shiny MUI Dialog here
-                    const result = confirm(t('{{ getTranslationKeyForVisualElement button }}.confirmation', { defaultValue: '{{ button.confirmation.confirmationMessage }}' }) as string);
+                    const result = await openConfirmDialog(
+                      '{{ getXMIID button }}',
+                      t('{{ getTranslationKeyForVisualElement button }}.confirmation', { defaultValue: '{{ button.confirmation.confirmationMessage }}' }) as string,
+                      t('judo.modal.confirm.confirm-title', { defaultValue: 'Confirm action' }) as string,
+                    );
 
                     if (!result) {
                       return;

--- a/judo-ui-react/src/main/resources/actor/src/fragments/container/common-imports.fragment.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/fragments/container/common-imports.fragment.hbs
@@ -32,6 +32,7 @@ import {
   DropdownButton,
   useJudoNavigation,
 } from '~/components';
+import { useConfirmDialog } from '~/components/dialog';
 import {
     isErrorOperationFault,
     useErrorHandler,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5350" title="JNG-5350" target="_blank"><img alt="Story" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />JNG-5350</a>  Use openConfirmDialog instead of confirm
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
