### PR TITLE
JNG-5347 add required disabled hidden apis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     name: ⏳ Build, test and deploy artifacts
     runs-on: judong
-    timeout-minutes: 30
+    timeout-minutes: 45
     env:
       SIGN_KEY_ID: ${{ secrets.GPG_KEYNAME }}
       SIGN_KEY_PASS: ${{ secrets.GPG_PASSPHRASE }}

--- a/docs/pages/01_ui_react.adoc
+++ b/docs/pages/01_ui_react.adoc
@@ -486,15 +486,73 @@ const nakedEyeColumnCustomizerHook: ColumnCustomizerHook<ViewGalaxyStored> = () 
 
 ----
 
-=== Implementing page actions
+=== Implementing container actions
 
-Every page has a set of Actions. These are typically actions triggered by buttons, or page lifecycle actions, and are
+Every container has a set of Actions. These are typically actions triggered by buttons, or page lifecycle actions, and are
 generated in a form of optional interface methods.
 
 These methods can be re-implemented one-by-one, and if the framework detects a "custom" version of a method, it will
 call that instead of the original (if any).
 
-Every page as a designated unique `INTERFACE_KEY` string and a corresponding action hook `type`.
+Every container as a designated unique `CONTAINER_ACTIONS_HOOK_INTERFACE_KEY` string and a corresponding action hook `type`.
+
+Container action APIs are always designed as React hooks in order to provide the ability of injecting / using other hooks
+inside our implementations.
+
+*Figuring out how to locate interface keys can be done via:*
+
+- Inspecting the pages / dialogs in dev-tools, and searching for the id of containers in the `src/containers` folder.
+
+*Registering implementations*
+
+Implementations can be registered in one central location: `src/custom/application-customizer.tsx`.
+
+*src/custom/application-customizer.tsx:*
+[source,typescriptjsx]
+----
+import type { BundleContext } from '@pandino/pandino-api';
+import type { ApplicationCustomizer } from './interfaces';
+import { VIEW_GALAXY_VIEW_CONTAINER_ACTIONS_HOOK_INTERFACE_KEY, ViewGalaxyViewContainerHook } from '~/containers/View/Galaxy/View/ViewGalaxyView';
+import type { ViewGalaxy, ViewGalaxyStored } from '~/services/data-api';
+import { GOD_GALAXIES_ACCESS_VIEW_PAGE_ACTIONS_HOOK_INTERFACE_KEY, ViewGalaxyViewActionsHook } from '~/pages/God/Galaxies/AccessViewPage';
+
+export class DefaultApplicationCustomizer implements ApplicationCustomizer {
+  async customize(context: BundleContext): Promise<void> {
+    // Since we are implementing the `isAstronomerRequired` method on both levels, the page level implementation will
+    // have precedence, but only on the page GOD_GALAXIES_ACCESS_VIEW_PAGE!
+    context.registerService<ViewGalaxyViewActionsHook>(GOD_GALAXIES_ACCESS_VIEW_PAGE_ACTIONS_HOOK_INTERFACE_KEY, pageLevelHook);
+    context.registerService<ViewGalaxyViewContainerHook>(VIEW_GALAXY_VIEW_CONTAINER_ACTIONS_HOOK_INTERFACE_KEY, containerLevelHook);
+  }
+}
+
+const pageLevelHook: ViewGalaxyViewActionsHook = () => {
+  return {
+    isAstronomerRequired: (data: ViewGalaxy | ViewGalaxyStored, editMode?: boolean) => {
+      return data.name === 'BBB';
+    },
+  };
+};
+
+const containerLevelHook: ViewGalaxyViewContainerHook = () => {
+  return {
+    isAstronomerRequired: (data: ViewGalaxy | ViewGalaxyStored, editMode?: boolean) => {
+      return data.name === 'CCC';
+    },
+  };
+};
+----
+
+=== Implementing page actions
+
+Every page has a set of Actions. These are typically actions triggered by buttons, or page lifecycle actions, and are
+generated in a form of optional interface methods.
+
+> Action specifications on the page level take precedence over Container level actions when signatures match.
+
+These methods can be re-implemented one-by-one, and if the framework detects a "custom" version of a method, it will
+call that instead of the original (if any).
+
+Every page as a designated unique `PAGE_ACTIONS_HOOK_INTERFACE_KEY` string and a corresponding action hook `type`.
 
 Page action APIs are always designed as React hooks in order to provide the ability of injecting / using other hooks
 inside our implementations.

--- a/docs/pages/01_ui_react.adoc
+++ b/docs/pages/01_ui_react.adoc
@@ -488,13 +488,13 @@ const nakedEyeColumnCustomizerHook: ColumnCustomizerHook<ViewGalaxyStored> = () 
 
 === Implementing container actions
 
-Every container has a set of Actions. These are typically actions triggered by buttons, or page lifecycle actions, and are
-generated in a form of optional interface methods.
+Every container has a set of Actions. These are typically actions triggered by buttons, or visual lifecycle calculated
+properties. These actions are generated as optional methods.
 
-These methods can be re-implemented one-by-one, and if the framework detects a "custom" version of a method, it will
+These methods can be (re)implemented one-by-one, and if the framework detects a "custom" version of a method, it will
 call that instead of the original (if any).
 
-Every container as a designated unique `CONTAINER_ACTIONS_HOOK_INTERFACE_KEY` string and a corresponding action hook `type`.
+Every container has a designated unique `CONTAINER_ACTIONS_HOOK_INTERFACE_KEY` string and a corresponding action hook `type`.
 
 Container action APIs are always designed as React hooks in order to provide the ability of injecting / using other hooks
 inside our implementations.
@@ -549,7 +549,7 @@ generated in a form of optional interface methods.
 
 > Action specifications on the page level take precedence over Container level actions when signatures match.
 
-These methods can be re-implemented one-by-one, and if the framework detects a "custom" version of a method, it will
+These methods can be (re)implemented one-by-one, and if the framework detects a "custom" version of a method, it will
 call that instead of the original (if any).
 
 Every page as a designated unique `PAGE_ACTIONS_HOOK_INTERFACE_KEY` string and a corresponding action hook `type`.

--- a/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/UiActionsHelper.java
+++ b/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/UiActionsHelper.java
@@ -324,4 +324,17 @@ public class UiActionsHelper {
 
         return String.join(", ", tokens);
     }
+
+    public static String inputModifierParams(PageContainer container, Boolean checkIsLoading) {
+        List<String> tokens = new ArrayList<>();
+        if (!container.isTable()) {
+            tokens.add("data: " + classDataName((ClassType) container.getDataElement(), "") + " | " + classDataName((ClassType) container.getDataElement(), "Stored"));
+            tokens.add("editMode?: boolean");
+            if (checkIsLoading != null && checkIsLoading) {
+                tokens.add("isLoading?: boolean");
+            }
+        }
+
+        return String.join(", ", tokens);
+    }
 }

--- a/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/UiGeneralHelper.java
+++ b/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/UiGeneralHelper.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static hu.blackbelt.judo.ui.generator.typescript.rest.commons.UiCommonsHelper.getXMIID;
+import static java.util.Arrays.stream;
 
 @Log
 @TemplateHelper
@@ -50,6 +51,10 @@ public class UiGeneralHelper {
                 .replaceAll("/", "-")
                 .replaceAll("([a-z])([A-Z]+)", "$1-$2")
                 .toLowerCase();
+    }
+
+    public static String safeName(NamedElement namedElement) {
+        return stream(namedElement.getName().split("::")).map(org.springframework.util.StringUtils::capitalize).collect(Collectors.joining(""));
     }
 
     public static String toUnderscore(String fqName) {

--- a/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/UiPageContainerHelper.java
+++ b/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/UiPageContainerHelper.java
@@ -257,4 +257,14 @@ public class UiPageContainerHelper {
         List<Flex> acc = collectElementsOfType(container, new ArrayList<>(), Flex.class);
         return acc.stream().anyMatch(Flex::isCard);
     }
+
+    public static List<Input> getInputsForContainer(PageContainer container) {
+        Set<VisualElement> elements = new LinkedHashSet<>();
+        collectVisualElementsMatchingCondition(container, e -> e instanceof Input, elements);
+        return elements.stream().map(e -> ((Input) e)).sorted(Comparator.comparing(NamedElement::getFQName)).collect(Collectors.toList());
+    }
+
+    public static List<Link> getLinksForContainer(PageContainer container) {
+        return container.getLinks().stream().map(e -> ((Link) e)).sorted(Comparator.comparing(NamedElement::getFQName)).collect(Collectors.toList());
+    }
 }

--- a/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/UiPandinoHelper.java
+++ b/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/UiPandinoHelper.java
@@ -106,4 +106,10 @@ public class UiPandinoHelper {
 
         return filtered.stream().sorted(Comparator.comparing(NamedElement::getFQName)).collect(Collectors.toList());
     }
+
+    public static List<VisualElement> getElementsWithHiddenBy(Container container) {
+        Set<VisualElement> elements = new LinkedHashSet<>();
+        collectVisualElementsMatchingCondition(container, e -> e.getHiddenBy() != null, elements);
+        return elements.stream().sorted(Comparator.comparing(NamedElement::getFQName)).collect(Collectors.toList());
+    }
 }

--- a/judo-ui-react/src/main/resources/actor/src/containers/components/link.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/components/link.tsx.hbs
@@ -16,6 +16,8 @@ export interface {{ componentName link }}ActionDefinitions {
   {{# if link.onBlur }}
   on{{ firstToUpper link.relationType.name }}BlurAction?: ({{{ onBlurActionParams container }}}) => void;
   {{/ if }}
+  is{{ firstToUpper link.relationType.name }}Required?: ({{{ inputModifierParams container false }}}) => boolean;
+  is{{ firstToUpper link.relationType.name }}Disabled?: ({{{ inputModifierParams container true }}}) => boolean;
 }
 
 export interface {{ componentName link }}Props {
@@ -26,12 +28,13 @@ export interface {{ componentName link }}Props {
   validationError?: string;
   disabled?: boolean;
   editMode?: boolean;
+  isLoading?: boolean;
 }
 
 // XMIID: {{ getXMIID link }}
 // Name: {{ link.name }}
 export function {{ componentName link }}(props: {{ componentName link }}Props) {
-  const { ownerData, actions, storeDiff, submit, validationError, disabled, editMode } = props;
+  const { ownerData, actions, storeDiff, submit, validationError, disabled, editMode, isLoading } = props;
   const { t } = useTranslation();
 
   return (
@@ -44,14 +47,14 @@ export function {{ componentName link }}(props: {{ componentName link }}Props) {
         ownerData.{{ link.dataElement.name }}?.{{ part.attributeType.name }}?.toString() ?? '',
         {{/ each }}
       ]}
-      required={ {{# if link.requiredBy }}ownerData.{{ link.requiredBy.name }} || {{/ if }}{{# unless link.dataElement.isOptional }}true{{ else }}false{{/ unless }} }
+      required={actions?.is{{ firstToUpper link.relationType.name }}Required ? actions.is{{ firstToUpper link.relationType.name }}Required(ownerData, editMode) : ({{# if link.requiredBy }}ownerData.{{ link.requiredBy.name }} || {{/ if }}{{# unless link.dataElement.isOptional }}true{{ else }}false{{/ unless }})}
       ownerData={ownerData}
       error={!!validationError}
       helperText={validationError}
       {{# if link.icon }}
         icon={<MdiIcon path="{{ link.icon.iconName }}" />}
       {{/ if }}
-      disabled={disabled}
+      disabled={actions?.is{{ firstToUpper link.relationType.name }}Disabled ? actions.is{{ firstToUpper link.relationType.name }}Disabled(ownerData, editMode, isLoading) : disabled}
       editMode={editMode}
       autoCompleteAttribute={'{{ link.parts.[0].attributeType.name }}'}
       onAutoCompleteSelect={ ({{ link.dataElement.name }}) => {

--- a/judo-ui-react/src/main/resources/actor/src/containers/container.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/container.tsx.hbs
@@ -2,6 +2,8 @@
 
 {{# if isDebugPrint }}// include: actor/src/fragments/container/common-imports.fragment.hbs{{/ if }}
 {{> actor/src/fragments/container/common-imports.fragment.hbs }}
+import { OBJECTCLASS } from '@pandino/pandino-api';
+import { useTrackService } from '@pandino/react-hooks';
 {{# unless container.table }}
   {{# if isDebugPrint }}// include: actor/src/fragments/container/view-imports.fragment.hbs{{/ if }}
   {{> actor/src/fragments/container/view-imports.fragment.hbs }}
@@ -26,12 +28,28 @@
     export interface {{ getCustomizationComponentInterface ve }} extends FC<CustomFormVisualElementProps<{{ classDataName container.dataElement '' }}>> {}
 {{/ each }}
 
+export const {{ camelCaseNameToInterfaceKey (containerComponentName container) }}_CONTAINER_ACTIONS_HOOK_INTERFACE_KEY = '{{ containerComponentName container }}ContainerHook';
+export type {{ containerComponentName container }}ContainerHook = (
+  {{# unless container.table }}
+  data: {{ classDataName container.dataElement 'Stored' }}{{# if container.table }}[]{{/ if }},
+  editMode: boolean,
+  storeDiff: (attributeName: keyof {{ classDataName container.dataElement '' }}, value: any) => void,
+  {{/ unless }}
+) => {{ pageContainerActionDefinitionTypeName container }};
+
 export interface {{ pageContainerActionDefinitionTypeName container }}{{# if (containerHasRelationComponents container) }} extends {{# each (getContainerActionsExtends container) as |ext| }}{{ ext }}{{# unless @last}},{{/ unless}}{{/ each }}{{/ if }} {
   {{# each (getContainerOwnActionDefinitions container) as |actionDefinition| }}
     {{ simpleActionDefinitionName actionDefinition }}?: ({{{ getContainerOwnActionParameters actionDefinition container }}}) => Promise<{{ getContainerOwnActionReturnType actionDefinition container }}>;
   {{/ each }}
   {{# each (getOnBlurAttributesForContainer container) as |attributeType| }}
     on{{ firstToUpper attributeType.name }}BlurAction?: ({{{ onBlurActionParams container }}}) => void;
+  {{/ each }}
+  {{# each (getInputsForContainer container) as |input| }}
+    is{{ firstToUpper input.attributeType.name }}Required?: ({{{ inputModifierParams container false }}}) => boolean;
+    is{{ firstToUpper input.attributeType.name }}Disabled?: ({{{ inputModifierParams container true }}}) => boolean;
+  {{/ each}}
+  {{# each (getElementsWithHiddenBy container) as |ve| }}
+    is{{ safeName ve }}Hidden?: ({{{ inputModifierParams container false }}}) => boolean;
   {{/ each }}
 }
 {{/ unless }}
@@ -63,15 +81,22 @@ export interface {{ containerComponentName container }}Props {
 // Name: {{ container.name }}
 export default function {{ containerComponentName container }}(props: {{ containerComponentName container }}Props) {
   {{# unless (containerIsEmptyDashboard container) }}
+    // Container props
+    const { refreshCounter, actions: pageActions{{# if container.isSelector }}, selectionDiff, setSelectionDiff{{/ if }}{{# if container.isRelationSelector }}, alreadySelected{{/ if }}{{# unless container.table }}, data, isLoading, isFormUpdateable, isFormDeleteable, storeDiff, editMode, validation, setValidation, submit{{/ unless }} } = props;
+
+    // Container hooks
     const { t } = useTranslation();
     const { navigate, back } = useJudoNavigation();
-    const { refreshCounter, actions{{# if container.isSelector }}, selectionDiff, setSelectionDiff{{/ if }}{{# if container.isRelationSelector }}, alreadySelected{{/ if }}{{# unless container.table }}, data, isLoading, isFormUpdateable, isFormDeleteable, storeDiff, editMode, validation, setValidation, submit{{/ unless }} } = props;
     const { locale: l10nLocale } = useL10N();
     const { openConfirmDialog } = useConfirmDialog();
 
     {{# unless container.table }}
       useConfirmationBeforeChange(editMode, t('judo.form.navigation.confirmation', { defaultValue: 'You have potential unsaved changes in your form, are you sure you would like to navigate away?' }));
     {{/ unless }}
+    // Pandino Container Action overrides
+    const { service: customContainerHook } = useTrackService<{{ containerComponentName container }}ContainerHook>(`(${OBJECTCLASS}=${ {{~ camelCaseNameToInterfaceKey (containerComponentName container) }}_CONTAINER_ACTIONS_HOOK_INTERFACE_KEY})`);
+    const containerActions: {{ pageContainerActionDefinitionTypeName container }} = customContainerHook?.({{# unless container.table }}data, editMode, storeDiff{{/ unless }}) || {};
+    const actions = useMemo(() => ({...containerActions, ...pageActions}), [containerActions, pageActions]);
   {{/ unless }}
 
   return (

--- a/judo-ui-react/src/main/resources/actor/src/containers/container.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/container.tsx.hbs
@@ -31,7 +31,7 @@ import { useTrackService } from '@pandino/react-hooks';
 export const {{ camelCaseNameToInterfaceKey (containerComponentName container) }}_CONTAINER_ACTIONS_HOOK_INTERFACE_KEY = '{{ containerComponentName container }}ContainerHook';
 export type {{ containerComponentName container }}ContainerHook = (
   {{# unless container.table }}
-  data: {{ classDataName container.dataElement 'Stored' }}{{# if container.table }}[]{{/ if }},
+  data: {{ classDataName container.dataElement 'Stored' }},
   editMode: boolean,
   storeDiff: (attributeName: keyof {{ classDataName container.dataElement '' }}, value: any) => void,
   {{/ unless }}

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/binarytypeinput.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/binarytypeinput.hbs
@@ -1,4 +1,4 @@
-{{# if child.hiddenBy }} { !data.{{ child.hiddenBy.name }} && {{/ if }}
+{{# if child.hiddenBy }} { (actions?.is{{ safeName child }}Hidden ? actions?.is{{ safeName child }}Hidden(data, editMode) : !data.{{ child.hiddenBy.name }}) && {{/ if }}
 <Grid item xs={12} sm={12} {{# neq (calculateSize child) 12.0 }}md={ {{ calculateSize child }} }{{/ neq }}>
     {{# if child.customImplementation }}
         <ComponentProxy
@@ -7,10 +7,11 @@
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
+            isLoading={isLoading}
         >
     {{/ if }}
     <BinaryInput
-        required={ {{# if child.requiredBy }}data.{{ child.requiredBy.name }} ||{{/ if }} {{ boolValue child.attributeType.isRequired  }} }
+        required={actions?.is{{ firstToUpper child.attributeType.name }}Required ? actions.is{{ firstToUpper child.attributeType.name }}Required(data, editMode) : ({{# if child.requiredBy }}data.{{ child.requiredBy.name }} ||{{/ if }} {{ boolValue child.attributeType.isRequired  }})}
         id="{{ getXMIID child }}"
         label={t('{{ getTranslationKeyForVisualElement child }}', { defaultValue: '{{ child.label }}' }) as string}
         {{# if child.icon }}
@@ -27,7 +28,7 @@
         data={data}
         attributeName="{{ child.attributeType.name }}"
         attributePath="{{ attributePath child.attributeType }}"
-        disabled={ {{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} isLoading }
+        disabled={actions?.is{{ firstToUpper child.attributeType.name }}Disabled ? actions.is{{ firstToUpper child.attributeType.name }}Disabled(data, editMode, isLoading) : ({{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} isLoading)}
         readonly={ {{ boolValue child.attributeType.isReadOnly }} || !isFormUpdateable() }
         {{# unless child.attributeType.isReadOnly }}
             deleteCallback={ async () => {

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/button.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/button.hbs
@@ -1,4 +1,4 @@
-{{# if child.hiddenBy }} { !data.{{ child.hiddenBy.name }} && {{/ if }}
+{{# if child.hiddenBy }} { (actions?.is{{ safeName child }}Hidden ? actions?.is{{ safeName child }}Hidden(data, editMode) : !data.{{ child.hiddenBy.name }}) && {{/ if }}
 <Grid item xs={12} sm={12} {{# neq (calculateSize child) 12.0 }}md={ {{ calculateSize child }} }{{/ neq }}>
   {{# if child.customImplementation }}
     <ComponentProxy
@@ -7,6 +7,7 @@
       validation={validation}
       editMode={editMode}
       storeDiff={storeDiff}
+      isLoading={isLoading}
     >
   {{/ if }}
   {{# or child.actionDefinition.isCallOperationAction child.actionDefinition.isOpenFormAction }}

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/buttongroup.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/buttongroup.hbs
@@ -1,4 +1,4 @@
-{{# if child.hiddenBy }} { !data.{{ child.hiddenBy.name }} && {{/ if }}
+{{# if child.hiddenBy }} { (actions?.is{{ safeName child }}Hidden ? actions?.is{{ safeName child }}Hidden(data, editMode) : !data.{{ child.hiddenBy.name }}) && {{/ if }}
 <Grid item xs={12} {{# neq (calculateSize child) 12.0 }}sm={ {{ calculateSize child }} }{{/ neq }}>
   <Grid container spacing={2}>
     {{# if child.customImplementation }}
@@ -8,6 +8,7 @@
         validation={validation}
         editMode={editMode}
         storeDiff={storeDiff}
+        isLoading={isLoading}
       >
     {{/ if }}
     {{# each (featuredButtonsForButtonGroup child) as |button| }}

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/checkbox.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/checkbox.hbs
@@ -1,4 +1,4 @@
-{{# if child.hiddenBy }} { !data.{{ child.hiddenBy.name }} && {{/ if }}
+{{# if child.hiddenBy }} { (actions?.is{{ safeName child }}Hidden ? actions?.is{{ safeName child }}Hidden(data, editMode) : !data.{{ child.hiddenBy.name }}) && {{/ if }}
 <Grid item xs={12} sm={12} {{# neq (calculateSize child) 12.0 }}md={ {{ calculateSize child }} }{{/ neq }}>
     {{# if child.customImplementation }}
         <ComponentProxy
@@ -7,6 +7,7 @@
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
+            isLoading={isLoading}
         >
     {{/ if }}
         <FormControl error={!!validation.get('{{ child.attributeType.name }}')}>
@@ -14,7 +15,7 @@
                 <FormControlLabel
                     className="checkbox"
                     sx={ { marginTop: '6px', color: (theme) => validation.has('{{ child.attributeType.name }}') ? theme.palette.error.main : 'primary' } }
-                    disabled={ {{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} {{ boolValue child.attributeType.isReadOnly }} || !isFormUpdateable() || isLoading }
+                    disabled={actions?.is{{ firstToUpper child.attributeType.name }}Disabled ? actions.is{{ firstToUpper child.attributeType.name }}Disabled(data, editMode, isLoading) : ({{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} {{ boolValue child.attributeType.isReadOnly }} || !isFormUpdateable() || isLoading)}
                     control={
                         <Checkbox checked={ data.{{ child.attributeType.name }} || false } sx={ { color: (theme) => validation.has('{{ child.attributeType.name }}') ? theme.palette.error.main : 'primary' } } onChange={ (event) => {
                             storeDiff('{{ child.attributeType.name }}', event.target.checked);

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/dateinput.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/dateinput.hbs
@@ -1,4 +1,4 @@
-{{# if child.hiddenBy }} { !data.{{ child.hiddenBy.name }} && {{/ if }}
+{{# if child.hiddenBy }} { (actions?.is{{ safeName child }}Hidden ? actions?.is{{ safeName child }}Hidden(data, editMode) : !data.{{ child.hiddenBy.name }}) && {{/ if }}
 <Grid item xs={12} sm={12} {{# neq (calculateSize child) 12.0 }}md={ {{ calculateSize child }} }{{/ neq }}>
     {{# if child.customImplementation }}
         <ComponentProxy
@@ -7,6 +7,7 @@
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
+            isLoading={isLoading}
         >
     {{/ if }}
     <DatePicker
@@ -16,7 +17,7 @@
         slotProps={ {
             textField: {
                 id: '{{ getXMIID child }}',
-                required: {{# if child.requiredBy }}data.{{ child.requiredBy.name }} ||{{/ if }} {{ boolValue child.attributeType.isRequired  }},
+                required: actions?.is{{ firstToUpper child.attributeType.name }}Required ? actions.is{{ firstToUpper child.attributeType.name }}Required(data, editMode) : ({{# if child.requiredBy }}data.{{ child.requiredBy.name }} ||{{/ if }} {{ boolValue child.attributeType.isRequired  }}),
                 helperText: validation.get('{{ child.attributeType.name }}'),
                 error: !!validation.get('{{ child.attributeType.name }}'),
                 {{# if child.icon }}
@@ -48,7 +49,7 @@
         label={ t('{{ getTranslationKeyForVisualElement child }}', { defaultValue: '{{ child.label }}' }) as string }
         value={ serviceDateToUiDate(data.{{ child.attributeType.name }} ?? null) }
         readOnly={ {{ boolValue child.attributeType.isReadOnly }} || !isFormUpdateable() }
-        disabled={ {{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} isLoading }
+        disabled={actions?.is{{ firstToUpper child.attributeType.name }}Disabled ? actions.is{{ firstToUpper child.attributeType.name }}Disabled(data, editMode, isLoading) : ({{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} isLoading)}
         onChange={ (newValue?: any | null) => {
             storeDiff('{{ child.attributeType.name }}', newValue);
             {{# if child.onBlur }}

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/datetimeinput.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/datetimeinput.hbs
@@ -1,4 +1,4 @@
-{{# if child.hiddenBy }} { !data.{{ child.hiddenBy.name }} && {{/ if }}
+{{# if child.hiddenBy }} { (actions?.is{{ safeName child }}Hidden ? actions?.is{{ safeName child }}Hidden(data, editMode) : !data.{{ child.hiddenBy.name }}) && {{/ if }}
 <Grid item xs={12} sm={12} {{# neq (calculateSize child) 12.0 }}md={ {{ calculateSize child }} }{{/ neq }}>
     {{# if child.customImplementation }}
         <ComponentProxy
@@ -7,6 +7,7 @@
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
+            isLoading={isLoading}
         >
     {{/ if }}
     <DateTimePicker
@@ -22,7 +23,7 @@
         slotProps={ {
             textField: {
                 id: '{{ getXMIID child }}',
-                required: {{# if child.requiredBy }}data.{{ child.requiredBy.name }} ||{{/ if }} {{ boolValue child.attributeType.isRequired  }},
+                required: actions?.is{{ firstToUpper child.attributeType.name }}Required ? actions.is{{ firstToUpper child.attributeType.name }}Required(data, editMode) : ({{# if child.requiredBy }}data.{{ child.requiredBy.name }} ||{{/ if }} {{ boolValue child.attributeType.isRequired  }}),
                 helperText: validation.get('{{ child.attributeType.name }}'),
                 error: !!validation.get('{{ child.attributeType.name }}'),
                 {{# if child.icon }}
@@ -50,7 +51,7 @@
         label={ t('{{ getTranslationKeyForVisualElement child }}', { defaultValue: '{{ child.label }}' }) as string }
         value={ serviceDateToUiDate(data.{{ child.attributeType.name }} ?? null) }
         readOnly={ {{ boolValue child.attributeType.isReadOnly }} || !isFormUpdateable() }
-        disabled={ {{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} isLoading }
+        disabled={actions?.is{{ firstToUpper child.attributeType.name }}Disabled ? actions.is{{ firstToUpper child.attributeType.name }}Disabled(data, editMode, isLoading) : ({{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} isLoading)}
         onChange={ (newValue: Date) => {
             storeDiff('{{ child.attributeType.name }}', newValue);
             {{# if child.onBlur }}

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/divider.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/divider.hbs
@@ -1,4 +1,4 @@
-{{# if child.hiddenBy }} { !data.{{ child.hiddenBy.name }} && {{/ if }}
+{{# if child.hiddenBy }} { (actions?.is{{ safeName child }}Hidden ? actions?.is{{ safeName child }}Hidden(data, editMode) : !data.{{ child.hiddenBy.name }}) && {{/ if }}
 <Grid item xs={12} sm={12} {{# neq (calculateSize child) 12.0 }}md={ {{ calculateSize child }} }{{/ neq }}>
     {{# if child.customImplementation }}
         <ComponentProxy
@@ -7,6 +7,7 @@
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
+            isLoading={isLoading}
         >
     {{/ if }}
     <Grid container sx={ { height: DIVIDER_HEIGHT } } alignItems="center">

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/enumerationcombo.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/enumerationcombo.hbs
@@ -1,4 +1,4 @@
-{{# if child.hiddenBy }} { !data.{{ child.hiddenBy.name }} && {{/ if }}
+{{# if child.hiddenBy }} { (actions?.is{{ safeName child }}Hidden ? actions?.is{{ safeName child }}Hidden(data, editMode) : !data.{{ child.hiddenBy.name }}) && {{/ if }}
 <Grid item xs={12} sm={12} {{# neq (calculateSize child) 12.0 }}md={ {{ calculateSize child }} }{{/ neq }}>
     {{# if child.customImplementation }}
         <ComponentProxy
@@ -7,10 +7,11 @@
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
+            isLoading={isLoading}
         >
     {{/ if }}
     <TextField
-        required={ {{# if child.requiredBy }}data.{{ child.requiredBy.name }} ||{{/ if }} {{ boolValue child.attributeType.isRequired  }} }
+        required={actions?.is{{ firstToUpper child.attributeType.name }}Required ? actions.is{{ firstToUpper child.attributeType.name }}Required(data, editMode) : ({{# if child.requiredBy }}data.{{ child.requiredBy.name }} ||{{/ if }} {{ boolValue child.attributeType.isRequired  }})}
         name="{{ child.attributeType.name }}"
         id="{{ getXMIID child }}"
         {{# if (shouldElementHaveAutoFocus child) }}
@@ -22,7 +23,7 @@
             'JUDO-viewMode': !editMode,
             'JUDO-required': {{ boolValue child.attributeType.isRequired }},
         }) }
-        disabled={ {{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} isLoading }
+        disabled={actions?.is{{ firstToUpper child.attributeType.name }}Disabled ? actions.is{{ firstToUpper child.attributeType.name }}Disabled(data, editMode, isLoading) : ({{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} isLoading)}
         error={ !!validation.get('{{ child.attributeType.name }}') }
         helperText={ validation.get('{{ child.attributeType.name }}') }
         {{# if child.onBlur }}

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/enumerationradio.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/enumerationradio.hbs
@@ -1,4 +1,4 @@
-{{# if child.hiddenBy }} { !data.{{ child.hiddenBy.name }} && {{/ if }}
+{{# if child.hiddenBy }} { (actions?.is{{ safeName child }}Hidden ? actions?.is{{ safeName child }}Hidden(data, editMode) : !data.{{ child.hiddenBy.name }}) && {{/ if }}
 <Grid item xs={12} sm={12} {{# neq (calculateSize child) 12.0 }}md={ {{ calculateSize child }} }{{/ neq }}>
     {{# if child.customImplementation }}
         <ComponentProxy
@@ -7,6 +7,7 @@
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
+            isLoading={isLoading}
         >
     {{/ if }}
     <FormControl
@@ -43,7 +44,7 @@
                 value={ '{{ member.name }}' }
                 control={<Radio size='small' />}
                 label= { t('enumerations.{{ restParamName child.attributeType.dataType }}.{{ member.name }}', { defaultValue: '{{ member.name }}' }) }
-                disabled={ {{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} {{ boolValue child.attributeType.isReadOnly }} || !isFormUpdateable() }
+                disabled={actions?.is{{ firstToUpper child.attributeType.name }}Disabled ? actions.is{{ firstToUpper child.attributeType.name }}Disabled(data, editMode, isLoading) : ({{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} {{ boolValue child.attributeType.isReadOnly }} || !isFormUpdateable())}
             />
         {{/ each }}
         </RadioGroup>

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/flex.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/flex.hbs
@@ -1,4 +1,4 @@
-{{# if this.hiddenBy }} { !data.{{ this.hiddenBy.name }} && {{/ if }}
+{{# if this.hiddenBy }} { (actions?.is{{ safeName child }}Hidden ? actions?.is{{ safeName child }}Hidden(data, editMode) : !data.{{ this.hiddenBy.name }}) && {{/ if }}
 <Grid item xs={12} sm={12} {{# neq (calculateSize this) 12.0 }}md={ {{ calculateSize this }} }{{/ neq }}>
     {{# if this.customImplementation }}
         <ComponentProxy
@@ -7,6 +7,7 @@
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
+            isLoading={isLoading}
         >
     {{/ if }}
     {{# if this.card }}

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/formatted.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/formatted.hbs
@@ -1,4 +1,4 @@
-{{# if child.hiddenBy }} { !data.{{ child.hiddenBy.name }} && {{/ if }}
+{{# if child.hiddenBy }} { (actions?.is{{ safeName child }}Hidden ? actions?.is{{ safeName child }}Hidden(data, editMode) : !data.{{ child.hiddenBy.name }}) && {{/ if }}
 <Grid item xs={12} sm={12} {{# neq (calculateSize child) 12.0 }}md={ {{ calculateSize child }} }{{/ neq }}>
     {{# if child.customImplementation }}
         <ComponentProxy
@@ -7,6 +7,7 @@
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
+            isLoading={isLoading}
         >
     {{/ if }}
     <Grid container direction="row" alignItems="center" {{# if child.icon }}spacing={2}{{/ if }}>

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/label.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/label.hbs
@@ -1,4 +1,4 @@
-{{# if child.hiddenBy }} { !data.{{ child.hiddenBy.name }} && {{/ if }}
+{{# if child.hiddenBy }} { (actions?.is{{ safeName child }}Hidden ? actions?.is{{ safeName child }}Hidden(data, editMode) : !data.{{ child.hiddenBy.name }}) && {{/ if }}
 <Grid item xs={12} sm={12} {{# neq (calculateSize child) 12.0 }}md={ {{ calculateSize child }} }{{/ neq }}>
     {{# if child.customImplementation }}
         <ComponentProxy
@@ -7,6 +7,7 @@
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
+            isLoading={isLoading}
         >
     {{/ if }}
     <Grid container direction="row" alignItems="center" justifyContent="flex-start">

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/link.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/link.hbs
@@ -1,4 +1,4 @@
-{{# if child.hiddenBy }} { !data.{{ child.hiddenBy.name }} && {{/ if }}
+{{# if child.hiddenBy }} { (actions?.is{{ safeName child }}Hidden ? actions?.is{{ safeName child }}Hidden(data, editMode) : !data.{{ child.hiddenBy.name }}) && {{/ if }}
 <Grid item xs={12} sm={12} {{# neq (calculateSize child) 12.0 }}md={ {{ calculateSize child }} }{{/ neq }}>
     {{# if child.customImplementation }}
         <ComponentProxy
@@ -8,12 +8,14 @@
             editMode={editMode}
             validation={validation}
             actions={ actionsFor{{ componentName child }} }
+            isLoading={isLoading}
         >
     {{/ if }}
     <{{ componentName child }}
         disabled={ {{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} {{ boolValue child.dataElement.isReadOnly }} || !isFormUpdateable() }
         ownerData={data}
         editMode={editMode}
+        isLoading={isLoading}
         storeDiff={storeDiff}
         validationError={validation.get('{{ child.dataElement.name }}')}
         actions={actions}

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/numericinput.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/numericinput.hbs
@@ -1,4 +1,4 @@
-{{# if child.hiddenBy }} { !data.{{ child.hiddenBy.name }} && {{/ if }}
+{{# if child.hiddenBy }} { (actions?.is{{ safeName child }}Hidden ? actions?.is{{ safeName child }}Hidden(data, editMode) : !data.{{ child.hiddenBy.name }}) && {{/ if }}
 <Grid item xs={12} sm={12} {{# neq (calculateSize child) 12.0 }}md={ {{ calculateSize child }} }{{/ neq }}>
     {{# if child.customImplementation }}
         <ComponentProxy
@@ -7,10 +7,11 @@
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
+            isLoading={isLoading}
         >
     {{/ if }}
     <NumericInput
-        required={ {{# if child.requiredBy }}data.{{ child.requiredBy.name }} ||{{/ if }} {{ boolValue child.attributeType.isRequired  }} }
+        required={actions?.is{{ firstToUpper child.attributeType.name }}Required ? actions.is{{ firstToUpper child.attributeType.name }}Required(data, editMode) : ({{# if child.requiredBy }}data.{{ child.requiredBy.name }} ||{{/ if }} {{ boolValue child.attributeType.isRequired  }})}
         name="{{ child.attributeType.name }}"
         id="{{ getXMIID child }}"
         {{# if (shouldElementHaveAutoFocus child) }}
@@ -26,7 +27,7 @@
             'JUDO-viewMode': !editMode,
             'JUDO-required': {{ boolValue child.attributeType.isRequired }},
         }) }
-        disabled={ {{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} isLoading }
+        disabled={actions?.is{{ firstToUpper child.attributeType.name }}Disabled ? actions.is{{ firstToUpper child.attributeType.name }}Disabled(data, editMode, isLoading) : ({{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} isLoading)}
         error={ !!validation.get('{{ child.attributeType.name }}') }
         helperText={ validation.get('{{ child.attributeType.name }}') }
         {{# if child.onBlur }}

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/spacer.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/spacer.hbs
@@ -1,4 +1,4 @@
-{{# if child.hiddenBy }} { !data.{{ child.hiddenBy.name }} && {{/ if }}
+{{# if child.hiddenBy }} { (actions?.is{{ safeName child }}Hidden ? actions?.is{{ safeName child }}Hidden(data, editMode) : !data.{{ child.hiddenBy.name }}) && {{/ if }}
 <Grid item xs={12} sm={12} {{# neq (calculateSize child) 12.0 }}md={ {{ calculateSize child }} }{{/ neq }}>
     {{# if child.customImplementation }}
         <ComponentProxy
@@ -7,6 +7,7 @@
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
+            isLoading={isLoading}
         >
     {{/ if }}
     <Grid container sx={ { height: DIVIDER_HEIGHT } } id="{{ getXMIID child }}"></Grid>

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/tabcontroller.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/tabcontroller.hbs
@@ -1,4 +1,4 @@
-{{# if child.hiddenBy }} { !data.{{ child.hiddenBy.name }} && {{/ if }}
+{{# if child.hiddenBy }} { (actions?.is{{ safeName child }}Hidden ? actions?.is{{ safeName child }}Hidden(data, editMode) : !data.{{ child.hiddenBy.name }}) && {{/ if }}
 <Grid container item xs={12} sm={12} {{# neq (calculateSize child) 12.0 }}md={ {{ calculateSize child }} }{{/ neq }}>
     {{# if child.customImplementation }}
         <ComponentProxy
@@ -7,6 +7,7 @@
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
+            isLoading={isLoading}
         >
     {{/ if }}
     <ModeledTabs
@@ -21,7 +22,7 @@
                     name: '{{ getTranslationKeyForVisualElement tab.element }}',
                     label: t('{{ getTranslationKeyForVisualElement tab.element }}', { defaultValue: '{{ tab.element.label }}' }) as string,
                     disabled: {{# if tab.element.enabledBy }}!data.{{ tab.element.enabledBy.name }} ||{{/ if }} isLoading,
-                    hidden: {{# if tab.element.hiddenBy }}data.{{ tab.element.hiddenBy.name }}{{ else }}false{{/ if }},
+                    hidden: {{# if tab.element.hiddenBy }}actions?.is{{ safeName tab.element }}Hidden ? actions?.is{{ safeName tab.element }}Hidden(data, editMode) : data.{{ tab.element.hiddenBy.name }}){{ else }}false{{/ if }},
                     {{# if tab.element.icon }}
                         icon: '{{ tab.element.icon.iconName }}',
                     {{/ if }}

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/table.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/table.hbs
@@ -1,4 +1,4 @@
-{{# if child.hiddenBy }} { !data.{{ child.hiddenBy.name }} && {{/ if }}
+{{# if child.hiddenBy }} { (actions?.is{{ safeName child }}Hidden ? actions?.is{{ safeName child }}Hidden(data, editMode) : !data.{{ child.hiddenBy.name }}) && {{/ if }}
 <Grid item xs={12} sm={12} {{# neq (calculateSize child) 12.0 }}md={ {{ calculateSize child }} }{{/ neq }}>
     {{# if child.customImplementation }}
         <ComponentProxy

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/text.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/text.hbs
@@ -1,4 +1,4 @@
-{{# if child.hiddenBy }} { !data.{{ child.hiddenBy.name }} && {{/ if }}
+{{# if child.hiddenBy }} { (actions?.is{{ safeName child }}Hidden ? actions?.is{{ safeName child }}Hidden(data, editMode) : !data.{{ child.hiddenBy.name }}) && {{/ if }}
 <Grid item xs={12} sm={12} {{# neq (calculateSize child) 12.0 }}md={ {{ calculateSize child }} }{{/ neq }}>
     {{# if child.customImplementation }}
         <ComponentProxy
@@ -7,6 +7,7 @@
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
+            isLoading={isLoading}
         >
     {{/ if }}
     <Typography id="{{ getXMIID child }}">

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/textarea.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/textarea.hbs
@@ -1,4 +1,4 @@
-{{# if child.hiddenBy }} { !data.{{ child.hiddenBy.name }} && {{/ if }}
+{{# if child.hiddenBy }} { (actions?.is{{ safeName child }}Hidden ? actions?.is{{ safeName child }}Hidden(data, editMode) : !data.{{ child.hiddenBy.name }}) && {{/ if }}
 <Grid item xs={12} sm={12} {{# neq (calculateSize child) 12.0 }}md={ {{ calculateSize child }} }{{/ neq }}>
     {{# if child.customImplementation }}
         <ComponentProxy
@@ -7,10 +7,11 @@
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
+            isLoading={isLoading}
         >
     {{/ if }}
     <TextField
-        required={ {{# if child.requiredBy }}data.{{ child.requiredBy.name }} ||{{/ if }} {{ boolValue child.attributeType.isRequired  }} }
+        required={actions?.is{{ firstToUpper child.attributeType.name }}Required ? actions.is{{ firstToUpper child.attributeType.name }}Required(data, editMode) : ({{# if child.requiredBy }}data.{{ child.requiredBy.name }} ||{{/ if }} {{ boolValue child.attributeType.isRequired  }})}
         name="{{ child.attributeType.name }}"
         id="{{ getXMIID child }}"
         {{# if (shouldElementHaveAutoFocus child) }}
@@ -22,7 +23,7 @@
             'JUDO-viewMode': !editMode,
             'JUDO-required': {{ boolValue child.attributeType.isRequired }},
         }) }
-        disabled={ {{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} isLoading }
+        disabled={actions?.is{{ firstToUpper child.attributeType.name }}Disabled ? actions.is{{ firstToUpper child.attributeType.name }}Disabled(data, editMode, isLoading) : ({{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} isLoading)}
         multiline
         minRows={ {{ child.row }} }
         error={ !!validation.get('{{ child.attributeType.name }}') }
@@ -49,6 +50,11 @@
                 ),
             {{/ if }}
         } }
+        {{# if child.attributeType.dataType.maxLength }}
+        inputProps={ {
+            maxlength: {{ child.attributeType.dataType.maxLength }},
+        } }
+        {{/ if }}
     />
     {{# if child.customImplementation }}
         </ComponentProxy>

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/textinput.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/textinput.hbs
@@ -1,4 +1,4 @@
-{{# if child.hiddenBy }} { !data.{{ child.hiddenBy.name }} && {{/ if }}
+{{# if child.hiddenBy }} { (actions?.is{{ safeName child }}Hidden ? actions?.is{{ safeName child }}Hidden(data, editMode) : !data.{{ child.hiddenBy.name }}) && {{/ if }}
 <Grid item xs={12} sm={12} {{# neq (calculateSize child) 12.0 }}md={ {{ calculateSize child }} }{{/ neq }}>
     {{# if child.customImplementation }}
         <ComponentProxy
@@ -7,10 +7,11 @@
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
+            isLoading={isLoading}
         >
     {{/ if }}
     <TextField
-        required={ {{# if child.requiredBy }}data.{{ child.requiredBy.name }} ||{{/ if }} {{ boolValue child.attributeType.isRequired  }} }
+        required={actions?.is{{ firstToUpper child.attributeType.name }}Required ? actions.is{{ firstToUpper child.attributeType.name }}Required(data, editMode) : ({{# if child.requiredBy }}data.{{ child.requiredBy.name }} ||{{/ if }} {{ boolValue child.attributeType.isRequired  }})}
         name="{{ child.attributeType.name }}"
         id="{{ getXMIID child }}"
         {{# if (shouldElementHaveAutoFocus child) }}
@@ -22,7 +23,7 @@
             'JUDO-viewMode': !editMode,
             'JUDO-required': {{ boolValue child.attributeType.isRequired }},
         }) }
-        disabled={ {{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} isLoading }
+        disabled={actions?.is{{ firstToUpper child.attributeType.name }}Disabled ? actions.is{{ firstToUpper child.attributeType.name }}Disabled(data, editMode, isLoading) : ({{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} isLoading)}
         error={ !!validation.get('{{ child.attributeType.name }}') }
         helperText={ validation.get('{{ child.attributeType.name }}') }
         {{# if child.onBlur }}
@@ -47,6 +48,11 @@
                 ),
             {{/ if }}
         } }
+        {{# if child.attributeType.dataType.maxLength }}
+        inputProps={ {
+          maxlength: {{ child.attributeType.dataType.maxLength }},
+        } }
+        {{/ if }}
     />
     {{# if child.customImplementation }}
         </ComponentProxy>

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/timeinput.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/timeinput.hbs
@@ -1,4 +1,4 @@
-{{# if child.hiddenBy }} { !data.{{ child.hiddenBy.name }} && {{/ if }}
+{{# if child.hiddenBy }} { (actions?.is{{ safeName child }}Hidden ? actions?.is{{ safeName child }}Hidden(data, editMode) : !data.{{ child.hiddenBy.name }}) && {{/ if }}
 <Grid item xs={12} sm={12} {{# neq (calculateSize child) 12.0 }}md={ {{ calculateSize child }} }{{/ neq }}>
     {{# if child.customImplementation }}
         <ComponentProxy
@@ -7,6 +7,7 @@
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
+            isLoading={isLoading}
         >
     {{/ if }}
     <TimePicker
@@ -18,7 +19,7 @@
         slotProps={ {
             textField: {
                 id: '{{ getXMIID child }}',
-                required: {{# if child.requiredBy }}data.{{ child.requiredBy.name }} ||{{/ if }} {{ boolValue child.attributeType.isRequired  }},
+                required: actions?.is{{ firstToUpper child.attributeType.name }}Required ? actions.is{{ firstToUpper child.attributeType.name }}Required(data, editMode) : ({{# if child.requiredBy }}data.{{ child.requiredBy.name }} ||{{/ if }} {{ boolValue child.attributeType.isRequired  }}),
                 helperText: validation.get('{{ child.attributeType.name }}'),
                 error: !!validation.get('{{ child.attributeType.name }}'),
                 {{# if child.icon }}
@@ -50,7 +51,7 @@
         label={ t('{{ getTranslationKeyForVisualElement child }}', { defaultValue: '{{ child.label }}' }) as string }
         value={ serviceTimeToUiTime(data.{{ child.attributeType.name }} ?? null) }
         readOnly={ {{ boolValue child.attributeType.isReadOnly }} || !isFormUpdateable() }
-        disabled={ {{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} isLoading }
+        disabled={actions?.is{{ firstToUpper child.attributeType.name }}Disabled ? actions.is{{ firstToUpper child.attributeType.name }}Disabled(data, editMode, isLoading) : ({{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} isLoading)}
         {{# if child.onBlur }}
         onBlur={ () => {
             if (actions?.on{{ firstToUpper child.attributeType.name }}BlurAction) {

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/trinarylogiccombo.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/trinarylogiccombo.hbs
@@ -1,4 +1,4 @@
-{{# if child.hiddenBy }} { !data.{{ child.hiddenBy.name }} && {{/ if }}
+{{# if child.hiddenBy }} { (actions?.is{{ safeName child }}Hidden ? actions?.is{{ safeName child }}Hidden(data, editMode) : !data.{{ child.hiddenBy.name }}) && {{/ if }}
 <Grid item xs={12} sm={12} {{# neq (calculateSize child) 12.0 }}md={ {{ calculateSize child }} }{{/ neq }}>
     {{# if child.customImplementation }}
         <ComponentProxy
@@ -7,6 +7,7 @@
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
+            isLoading={isLoading}
         >
     {{/ if }}
     <TrinaryLogicCombobox
@@ -15,7 +16,7 @@
         {{# if (shouldElementHaveAutoFocus child) }}
             autoFocus={true}
         {{/ if }}
-        required={ {{# if child.requiredBy }}data.{{ child.requiredBy.name }} ||{{/ if }} {{ boolValue child.attributeType.isRequired  }} }
+        required={actions?.is{{ firstToUpper child.attributeType.name }}Required ? actions.is{{ firstToUpper child.attributeType.name }}Required(data, editMode) : ({{# if child.requiredBy }}data.{{ child.requiredBy.name }} ||{{/ if }} {{ boolValue child.attributeType.isRequired  }})}
         label={ t('{{ getTranslationKeyForVisualElement child }}', { defaultValue: '{{ child.label }}' }) as string }
         value={ data?.{{ child.attributeType.name }} }
         editMode={ editMode }
@@ -30,7 +31,7 @@
             }
             {{/ if }}
         } }
-        disabled={ {{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} {{ boolValue child.attributeType.isReadOnly }} || isLoading }
+        disabled={actions?.is{{ firstToUpper child.attributeType.name }}Disabled ? actions.is{{ firstToUpper child.attributeType.name }}Disabled(data, editMode, isLoading) : ({{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} {{ boolValue child.attributeType.isReadOnly }} || isLoading)}
         readOnly={ {{ boolValue child.attributeType.isReadOnly }} || !isFormUpdateable() }
     />
     {{# if child.customImplementation }}

--- a/judo-ui-react/src/main/resources/actor/src/fragments/container/common-imports.fragment.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/fragments/container/common-imports.fragment.hbs
@@ -1,10 +1,9 @@
 import type { Dispatch, SetStateAction, FC } from 'react';
-import { forwardRef, useEffect, useState, useCallback, useImperativeHandle } from 'react';
+import { forwardRef, useEffect, useState, useCallback, useImperativeHandle, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { LoadingButton } from '@mui/lab';
 import type { JudoIdentifiable } from '~/services/data-api/common';
 {{# if (containerHasCustomComponent container) }}
-import { OBJECTCLASS } from '@pandino/pandino-api';
 import { ComponentProxy } from '@pandino/react-hooks';
 import { CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY } from '~/custom';
 import type { CustomFormVisualElementProps } from '~/custom';


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5347" title="JNG-5347" target="_blank"><img alt="Story" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />JNG-5347</a>  Add is[attributeName]Disabled api to actions api
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

- https://blackbelt.atlassian.net/browse/JNG-5347
- https://blackbelt.atlassian.net/browse/JNG-5346
- https://blackbelt.atlassian.net/browse/JNG-5375

We had a missing "layer" in our APIs, which is the "container layer". This has been added, and purpose has been explained in the docs.

Long story short: visual properties such as blur, visibility, etc should be configurable on a visual level, which could reduce page-level redundant configurations since this way we can configure them at one spot.

Page-level actions have precedence over container level action implementations **ON A PER-ACTION BASIS**.
