### PR TITLE
JNG-5407 fix button group enabled by

### DIFF
--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/buttongroup.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/buttongroup.hbs
@@ -35,7 +35,7 @@
             {{/ if }}
             await actions.{{ simpleActionDefinitionName button.actionDefinition }}!();
           } : undefined }
-          disabled={ {{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} editMode }
+          disabled={ {{# if button.enabledBy }}!data.{{ button.enabledBy.name }} ||{{/ if }} editMode }
         >
           { t('{{ getTranslationKeyForVisualElement button }}', { defaultValue: '{{ button.label }}' }) }
         </LoadingButton>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5407" title="JNG-5407" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-5407</a>  EnabledBy and HiddenBy are not added to buttons if contained in action groups
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
