### PR TITLE
JNG-5547 always start autocomplete options with a clear state

### DIFF
--- a/judo-ui-react/src/main/resources/actor/src/components/widgets/AggregationInput.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/widgets/AggregationInput.tsx.hbs
@@ -137,6 +137,7 @@ export const AggregationInput = ({
           readOnly={effectiveReadOnly}
           onOpen={ () => {
             if (!readOnly) {
+              setOptions([]); // always start with a clean slate
               setAllowFetch(true);
               handleSearch('');
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5547" title="JNG-5547" target="_blank"><img alt="Task" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />JNG-5547</a>  Clear dropdown options before range call to prevent selecting outdated value
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
