### PR TITLE
JNG-5326 support multiple mime types

### DIFF
--- a/judo-ui-react/src/main/resources/actor/src/components/widgets/BinaryInput.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/widgets/BinaryInput.tsx.hbs
@@ -6,12 +6,16 @@ import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
 import TextField from '@mui/material/TextField';
 import { useSnacks } from '~/hooks';
+import { fileHandling } from '~/utilities';
 import { useTranslation } from 'react-i18next';
-import { toastConfig } from '../../config';
 import { MdiIcon } from '../MdiIcon';
-import { fileHandling } from '../../utilities';
 
-interface BinaryInputProps<P> {
+export interface MimeTypeDeclaration {
+    type: string;
+    subType: string;
+}
+
+export interface BinaryInputProps<P> {
     id: string;
     label: string;
     data: P;
@@ -25,10 +29,7 @@ interface BinaryInputProps<P> {
     uploadCallback?: (uploadedData: { token: string }) => Promise<any>;
     deleteCallback?: () => Promise<void>;
     icon?: string;
-    mimeType?: {
-        type: string,
-        subType: string,
-    };
+    mimeTypes?: MimeTypeDeclaration[];
 }
 
 export function BinaryInput<P>(props: BinaryInputProps<P>) {
@@ -90,7 +91,7 @@ export function BinaryInput<P>(props: BinaryInputProps<P>) {
                     onClick={() => downloadFile(props.data, props.attributeName as string, 'attachment')}
                     title={t('judo.component.BinaryInput.download', { defaultValue: 'Download file' }) as string}
                 >
-                    <MdiIcon path="download" mimeType={props.mimeType} />
+                    <MdiIcon path="download" mimeType={props.mimeTypes ? (props.mimeTypes.length > 1 ? { type: '*', subType: '*' } : props.mimeTypes[0]) : undefined} />
                 </IconButton>
             </Grid>}
             {props.data[props.attributeName] && <Grid item xs="auto">
@@ -109,7 +110,7 @@ export function BinaryInput<P>(props: BinaryInputProps<P>) {
                 onClick={() => fileInput.current!.click()}
                 title={t('judo.component.BinaryInput.upload', { defaultValue: 'Upload file' }) as string}
             >
-                <input ref={fileInput} hidden type="file" accept={props.mimeType && `${props.mimeType.type}/${props.mimeType.subType}`} onChange={ async (event: any) => {
+                <input ref={fileInput} hidden type="file" accept={props.mimeTypes?.map(m => `${m.type}/${m.subType}`).join(',')} onChange={ async (event: any) => {
                     try {
                         setIsUploading(true);
                         const uploadedData = await uploadFile(props.data, props.attributeName as string, event.target.files, props.attributePath);

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/binarytypeinput.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/binarytypeinput.hbs
@@ -18,10 +18,11 @@
         {{# if child.icon }}
             icon="{{ child.icon.iconName }}"
             {{# neq child.attributeType.dataType.mimeTypes.size 0 }}
-                mimeType={ {
-                    type: '{{ child.attributeType.dataType.mimeTypes.[0].type }}',
-                    subType: '{{ child.attributeType.dataType.mimeTypes.[0].subType }}',
-                } }
+                mimeTypes={[
+                    {{# each child.attributeType.dataType.mimeTypes as |mimeType| }}
+                        { type: '{{ mimeType.type }}', subType: '{{ mimeType.subType }}' },
+                    {{/ each }}
+                ]}
             {{/ neq }}
         {{/ if }}
         editMode={editMode}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5326" title="JNG-5326" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-5326</a>  Binary type only show the first Mime type.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Added multi support, but end result varies between OS/Browser types.