### PR TITLE
JNG-5728 tags input

### DIFF
--- a/judo-ui-react/src/main/resources/actor/src/components/widgets/Tags.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/widgets/Tags.tsx.hbs
@@ -1,0 +1,201 @@
+{{> fragment.header.hbs }}
+
+import { type MouseEvent, type SyntheticEvent, useCallback, useMemo, useState } from 'react';
+import clsx from 'clsx';
+import InputAdornment from '@mui/material/InputAdornment';
+import ButtonGroup from '@mui/material/ButtonGroup';
+import CircularProgress from '@mui/material/CircularProgress';
+import IconButton from '@mui/material/IconButton';
+import Autocomplete from '@mui/material/Autocomplete';
+import TextField from '@mui/material/TextField';
+import { MdiIcon } from '~/components/MdiIcon';
+import { debounce } from '@mui/material/utils';
+import { debounceInputs } from '~/config/general';
+import { QueryCustomizer } from '~/services/data-api/common/QueryCustomizer';
+import { FilterBytypesString } from '~/services/data-api/rest/FilterBytypesString';
+import { StringOperation } from '~/services/data-api/model/StringOperation';
+
+export interface TagsProps<P, T> {
+  id: string;
+  label: string;
+  ownerData: P;
+  name: keyof P;
+  error?: boolean;
+  readOnly?: boolean;
+  disabled?: boolean;
+  helperText?: string;
+  editMode?: boolean;
+  autoCompleteAttribute: keyof T;
+  onAutoCompleteSearch: (searchText: string, preparedQueryCustomizer: QueryCustomizer<T>) => Promise<T[]>;
+  additionalMaskAttributes?: string[];
+  limitOptions?: number;
+  onValueChange: (target: T[]) => Promise<void>;
+  onItemClick?: (target: T) => void;
+  onSearchDialogsClick?: () => void;
+  searchDialogTitle?: string;
+  searchDialogIcon?: string;
+  onCreateDialogsClick?: () => void;
+  createDialogTitle?: string;
+  createDialogIcon?: string;
+}
+
+/**
+ * Experimental Tags component to serve as an alternative to aggregation->association collections.
+*/
+export function Tags<P, T> (props: TagsProps<P, T>) {
+  const {
+    id,
+    label,
+    ownerData,
+    name,
+    error,
+    readOnly = false,
+    disabled = false,
+    helperText,
+    editMode = false,
+    autoCompleteAttribute,
+    onAutoCompleteSearch,
+    onValueChange,
+    onItemClick,
+    onSearchDialogsClick,
+    searchDialogTitle,
+    searchDialogIcon = 'link',
+    onCreateDialogsClick,
+    createDialogTitle,
+    createDialogIcon = 'file-document-plus',
+    additionalMaskAttributes = [],
+    limitOptions = 10,
+  } = props;
+  const [options, setOptions] = useState<any[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+
+  const handleSearch = async (searchText: string) => {
+    try {
+      setLoading(true);
+      const filter: FilterBytypesString[] = (ownerData[name] as T[] ?? []).map((c: any) => ({
+        value: c[autoCompleteAttribute]!,
+        operator: StringOperation.notEqual,
+      }));
+      if (searchText) {
+        filter.push({
+          value: `%${searchText}%`,
+          operator: StringOperation.like,
+        });
+      }
+      const queryCustomizer: QueryCustomizer<any> = {
+        _mask: `{${autoCompleteAttribute as string}${additionalMaskAttributes.length ? (',' + additionalMaskAttributes.join(',')) : ''}}`,
+        [autoCompleteAttribute]: filter,
+        _orderBy: [
+          {
+            attribute: autoCompleteAttribute as string,
+            descending: false,
+          }
+        ],
+        _seek: {
+          limit: limitOptions,
+        },
+      };
+      const response = await onAutoCompleteSearch(searchText, queryCustomizer);
+      setOptions(response);
+    } catch (error) {
+      console.error(error);
+      setOptions([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const onInputChange = useMemo(
+    () =>
+      debounce((event: any, value: string, reason: string) => {
+        if (reason !== 'reset') {
+          handleSearch(value);
+        }
+      }, debounceInputs),
+    [ownerData],
+  );
+
+  const onChange = useCallback((event: SyntheticEvent, value: (string | any)[]) => {
+    onValueChange(value as any);
+  }, [ownerData, onValueChange]);
+
+  const onChipClicked = useCallback((event: MouseEvent) => {
+    const label = (event.target as HTMLSpanElement).textContent;
+    if (label) {
+      const data = (ownerData[name] as T[] ?? []).find((c: any) => c[autoCompleteAttribute] === label);
+      if (data && onItemClick) {
+        onItemClick(data);
+      }
+    }
+  }, [ownerData, onItemClick]);
+
+  return (
+    <Autocomplete
+      multiple
+      freeSolo
+      clearOnBlur
+      id={id}
+      disabled={!readOnly && disabled}
+      readOnly={readOnly}
+      options={options}
+      loading={loading}
+      value={ownerData[name] as T[] ?? []}
+      disableClearable={true}
+      getOptionLabel={(option) => option[autoCompleteAttribute] ?? ''}
+      isOptionEqualToValue={(option, value) => option[autoCompleteAttribute] === value[autoCompleteAttribute]}
+      onOpen={ () => {
+        setOptions([]); // always start with a clean slate
+        handleSearch('');
+      } }
+      onInputChange={onInputChange}
+      onChange={onChange}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label={label}
+          className={clsx({
+            'JUDO-viewMode': !editMode,
+          })}
+          error={error}
+          helperText={helperText}
+          InputProps={ {
+            ...params.InputProps,
+            readOnly: readOnly,
+            endAdornment: (
+              <InputAdornment position="end">
+                <ButtonGroup
+                  aria-label="tags button group"
+                  className={clsx({
+                    'TagsButtonGroup': true,
+                  })}
+                >
+                  {loading ? (
+                    <CircularProgress color="inherit" size="1rem" className="TagsLoading" />
+                  ) : null}
+                  {(!readOnly && onCreateDialogsClick) ? <IconButton
+                    disabled={disabled}
+                    onClick={onCreateDialogsClick}
+                    title={createDialogTitle}
+                  >
+                    <MdiIcon path={createDialogIcon} />
+                  </IconButton> : null}
+                  {(!readOnly && onSearchDialogsClick) ? <IconButton
+                    disabled={disabled}
+                    onClick={onSearchDialogsClick}
+                    title={searchDialogTitle}
+                  >
+                    <MdiIcon path={searchDialogIcon} />
+                  </IconButton> : null}
+                </ButtonGroup>
+              </InputAdornment>
+            ),
+          } }
+        />
+      )}
+      ChipProps={ {
+        clickable: typeof onItemClick === 'function',
+        onClick: onChipClicked,
+      } }
+    />
+  );
+};

--- a/judo-ui-react/src/main/resources/actor/src/components/widgets/Tags.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/widgets/Tags.tsx.hbs
@@ -37,6 +37,9 @@ export interface TagsProps<P, T> {
   onCreateDialogsClick?: () => void;
   createDialogTitle?: string;
   createDialogIcon?: string;
+  onClearDialogsClick?: () => void;
+  clearTitle?: string;
+  clearIcon?: string;
 }
 
 /**
@@ -63,6 +66,9 @@ export function Tags<P, T> (props: TagsProps<P, T>) {
     onCreateDialogsClick,
     createDialogTitle,
     createDialogIcon = 'file-document-plus',
+    onClearDialogsClick,
+    clearTitle= 'Clear',
+    clearIcon = 'close',
     additionalMaskAttributes = [],
     limitOptions = 10,
   } = props;
@@ -171,6 +177,11 @@ export function Tags<P, T> (props: TagsProps<P, T>) {
                 >
                   {loading ? (
                     <CircularProgress color="inherit" size="1rem" className="TagsLoading" />
+                  ) : null}
+                  {!readOnly && onClearDialogsClick ? (
+                    <IconButton disabled={disabled} onClick={onClearDialogsClick} title={clearTitle}>
+                      <MdiIcon path={clearIcon} />
+                    </IconButton>
                   ) : null}
                   {(!readOnly && onCreateDialogsClick) ? <IconButton
                     disabled={disabled}

--- a/judo-ui-react/src/main/resources/actor/src/components/widgets/Tags.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/widgets/Tags.tsx.hbs
@@ -164,6 +164,7 @@ export function Tags<P, T> (props: TagsProps<P, T>) {
           })}
           error={error}
           helperText={helperText}
+          InputLabelProps={ { shrink: true } }
           InputProps={ {
             ...params.InputProps,
             readOnly: readOnly,

--- a/judo-ui-react/src/main/resources/actor/src/components/widgets/index.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/widgets/index.tsx.hbs
@@ -1,6 +1,7 @@
 {{> fragment.header.hbs }}
 
 export * from './SingleRelationInput';
+export * from './Tags';
 export * from './AssociationButton';
 export * from './BinaryInput';
 export * from './NumericInput';

--- a/judo-ui-react/src/main/resources/actor/src/theme/index.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/theme/index.tsx.hbs
@@ -54,6 +54,13 @@ const baseTheme = (paletteTheme: Theme) => createTheme(
           },
         },
       },
+      MuiChip: {
+        styleOverrides: {
+          root: {
+            height: '28px',
+          },
+        },
+      },
       MuiLoadingButton: {
         defaultProps: {
           variant: 'contained',
@@ -142,6 +149,14 @@ const baseTheme = (paletteTheme: Theme) => createTheme(
               right: 8,
             },
             '.AggregationInputButtonGroup .AggregationInputLoading': {
+              margin: 'auto 0',
+            },
+            '.TagsButtonGroup': {
+              position: 'absolute',
+              top: 'calc(50% - 14px)', // MUI internals have the same burned in values...
+              right: 8,
+            },
+            '.TagsButtonGroup .TagsLoading': {
               margin: 'auto 0',
             },
             '.MuiInputBase-root.MuiInputBase-formControl.MuiAutocomplete-inputRoot': {

--- a/judo-ui-react/src/main/resources/ui-react.yaml
+++ b/judo-ui-react/src/main/resources/ui-react.yaml
@@ -421,6 +421,10 @@ templates:
     pathExpression: "'src/components/widgets/SingleRelationInput.tsx'"
     templateName: actor/src/components/widgets/SingleRelationInput.tsx.hbs
 
+  - name: actor/src/components/widgets/Tags.tsx
+    pathExpression: "'src/components/widgets/Tags.tsx'"
+    templateName: actor/src/components/widgets/Tags.tsx.hbs
+
   - name: actor/src/components/widgets/AssociationButton.tsx
     pathExpression: "'src/components/widgets/AssociationButton.tsx'"
     templateName: actor/src/components/widgets/AssociationButton.tsx.hbs


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5728" title="JNG-5728" target="_blank"><img alt="Story" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />JNG-5728</a>  Add experimental Tags input support for aggregation tables
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5728" title="JNG-5728" target="_blank"><img alt="Story" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />JNG-5728</a>  Add experimental Tags input support for aggregation tables
  </td></table>
  <br />
 
[Screencast from 2024-05-17 19-41-49.webm](https://github.com/BlackBeltTechnology/judo-ui-react-template/assets/1084847/b71d8be3-fe67-4d30-aa25-65c41e007d7a)


[Screencast from 2024-05-17 19-55-47.webm](https://github.com/BlackBeltTechnology/judo-ui-react-template/assets/1084847/7ff70e9b-09c1-4d83-b94b-93d02e2529a6)

[Screencast from 2024-05-18 17-41-42.webm](https://github.com/BlackBeltTechnology/judo-ui-react-template/assets/1084847/be198d85-402e-4875-a9d2-515d6168014b)

-----------------------

```typescript
import type { BundleContext } from '@pandino/pandino-api';
import type { ApplicationCustomizer } from './interfaces';
import { useMemo, type FC } from 'react';
import { type ViewPlanet, type ViewPlanetStored } from '~/services/data-api/model/ViewPlanet';
import { CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY } from './custom-element-types';
import { VIEW_PLANET_VIEW_CREATURES_COMPONENT } from '~/containers/View/Planet/View/customization';
import { type ViewCreatureStored } from '~/services/data-api/model/ViewCreature';
import { ViewPlanetServiceImpl } from '~/services/data-axios/ViewPlanetServiceImpl';
import { judoAxiosProvider } from '~/services/data-axios/JudoAxiosProvider';
import { type ViewPlanetViewCreaturesComponentActionDefinitions } from '~/containers/View/Planet/View/components/ViewPlanetViewCreaturesComponent/types';
import { Tags } from '~/components/widgets/Tags';

export class DefaultApplicationCustomizer implements ApplicationCustomizer {
  async customize(context: BundleContext): Promise<void> {
    // register your implementations here
    context.registerService<FC<ProxyProps>>(CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY, CreaturesTags, {
      component: VIEW_PLANET_VIEW_CREATURES_COMPONENT,
    });
  }
}

const CreaturesTags: FC<ProxyProps> = (props) => {
  const { ownerData, editMode, isFormUpdateable, storeDiff, actions } = props;
  const service = useMemo(() => new ViewPlanetServiceImpl(judoAxiosProvider), []);

  return (
    <Tags<ViewPlanetStored, ViewCreatureStored>
      id="hello"
      label="Creatures"
      editMode={editMode}
      ownerData={ownerData}
      name="creatures"
      disabled={!isFormUpdateable()}
      autoCompleteAttribute="name"
      onAutoCompleteSearch={async (searchText, preparedQueryCustomizer) => {
        const { data: response } = await service.getRangeForCreatures(ownerData, preparedQueryCustomizer);
        return response;
      }}
      onValueChange={async (values) => storeDiff('creatures', values)}
      onItemClick={(target) => actions.creaturesOpenPageAction!(target)}
      onSearchDialogsClick={() => actions.creaturesOpenAddSelectorAction!()}
      onClearDialogsClick={() => storeDiff('creatures', [])}
    />
  );
};

interface ProxyProps {
  ownerData: ViewPlanetStored;
  isOwnerLoading?: boolean;
  actions: ViewPlanetViewCreaturesComponentActionDefinitions;
  editMode?: boolean;
  isFormUpdateable: () => boolean;
  storeDiff: (attributeName: keyof ViewPlanet, value: any) => void;
}
```
