### PR TITLE
JNG-5761 fix association table edit mode

### DIFF
--- a/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/UiWidgetHelper.java
+++ b/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/UiWidgetHelper.java
@@ -341,8 +341,13 @@ public class UiWidgetHelper {
         if (button.getActionDefinition().getIsOpenCreateFormAction() && !table.isIsEager() && container.isView()) {
             return "!editMode && (isFormUpdateable ? isFormUpdateable() : false)";
         }
-        if (button.getActionDefinition().getIsOpenSelectorAction() && container.isView()) {
-            return "(isFormUpdateable ? isFormUpdateable() : false)";
+        if (container.isView()) {
+            if (button.getActionDefinition().getIsOpenSelectorAction() || button.getActionDefinition().getIsRemoveAction()) {
+                return "(isFormUpdateable ? (isFormUpdateable()" + (!table.isIsEager() ? "&& !editMode" : "") + ") : false)";
+            }
+            if (button.getActionDefinition().getIsBulkRemoveAction() || button.getActionDefinition().getIsClearAction()) {
+                return "(isFormUpdateable ? (isFormUpdateable()" + (!table.isIsEager() ? "&& !editMode" : "") + " && selectionModel.length > 0) : false)";
+            }
         }
         if (button.getActionDefinition().getIsClearAction()) {
             String result = "data.length > 0";


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5761" title="JNG-5761" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-5761</a>  Association table add/remove buttons should be disabled in edit mode
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
