### PR TITLE
JNG-5923 fix post operation navigation

### DIFF
--- a/judo-ui-react/src/main/resources/actor/src/pages/actions/InputFormCallOperationAction.fragment.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/actions/InputFormCallOperationAction.fragment.hbs
@@ -20,7 +20,7 @@ const {{ simpleActionDefinitionName action.actionDefinition }} = async ({{# if a
       );
     } else {
       showSuccessSnack(t('judo.action.operation.success', { defaultValue: 'Operation executed successfully' }) as string);
-      onSubmit({{# if operation.output }}result{{/ if }});
+      await onSubmit({{# if operation.output }}result{{/ if }});
 
       {{# if operation.postCallAccessNavigation }}
         try {

--- a/judo-ui-react/src/main/resources/actor/src/pages/actions/InputSelectorCallOperationAction.fragment.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/pages/actions/InputSelectorCallOperationAction.fragment.hbs
@@ -14,7 +14,7 @@ const {{ simpleActionDefinitionName action.actionDefinition }} = async ({{# if a
       );
     } else {
       showSuccessSnack(t('judo.action.operation.success', { defaultValue: 'Operation executed successfully' }) as string);
-      onSubmit({{# if operation.output }}result{{/ if }});
+      await onSubmit({{# if operation.output }}result{{/ if }});
 
       {{# if operation.postCallAccessNavigation }}
         try {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5923" title="JNG-5923" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-5923</a>  Frontend does not navigate to / open operation output after successful call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
