### PR TITLE
JNG-6009 readonly enum combo derived

### DIFF
--- a/judo-ui-react-itest/ActionGroupTest/action_group_test__god/src/test/resources/snapshots/frontend-react/src/containers/View/Matter/Form/ViewMatterForm.tsx.snapshot
+++ b/judo-ui-react-itest/ActionGroupTest/action_group_test__god/src/test/resources/snapshots/frontend-react/src/containers/View/Matter/Form/ViewMatterForm.tsx.snapshot
@@ -142,6 +142,7 @@ export default function ViewMatterForm(props: ViewMatterFormProps) {
                   disabled={actions?.isTypeDisabled ? actions.isTypeDisabled(data, editMode, isLoading) : isLoading}
                   readOnly={
                     (actions?.isTypeReadonly ? actions.isTypeReadonly(data, editMode, isLoading) : false) ||
+                    false ||
                     !isFormUpdateable()
                   }
                   options={[

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/enumerationcombo.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/enumerationcombo.hbs
@@ -16,7 +16,7 @@
       autoHighlight
       value={data.{{ child.attributeType.name }} || null}
       disabled={actions?.is{{ firstToUpper child.attributeType.name }}Disabled ? actions.is{{ firstToUpper child.attributeType.name }}Disabled(data, editMode, isLoading) : ({{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} isLoading)}
-      readOnly={(actions?.is{{ firstToUpper child.attributeType.name }}Readonly ? actions.is{{ firstToUpper child.attributeType.name }}Readonly(data, editMode, isLoading) : false) || !isFormUpdateable()}
+      readOnly={(actions?.is{{ firstToUpper child.attributeType.name }}Readonly ? actions.is{{ firstToUpper child.attributeType.name }}Readonly(data, editMode, isLoading) : false) || {{ boolValue child.attributeType.isReadOnly }} || !isFormUpdateable()}
       options={[
         ...effective{{ firstToUpper child.attributeType.name }}Options.map((o) => ({
           label: t(o.i18nKey, { defaultValue: o.i18nDefaultValue }),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-6009" title="JNG-6009" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-6009</a>  Derived enum field is not readonly and modifying its value triggers edit mode
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
