### PR TITLE
JNG-6019 fix typeahead onChange

### DIFF
--- a/judo-ui-react/src/main/resources/actor/src/components/widgets/TextWithTypeAhead.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/widgets/TextWithTypeAhead.tsx.hbs
@@ -136,6 +136,7 @@ export const TextWithTypeAhead = ({
       onInputChange={onInputChange}
       onChange={ (event, target) => {
         setValue(target);
+        onChange(target);
         handleSearch(target);
       } }
     />


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-6019" title="JNG-6019" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-6019</a>  Typeahead - selecting value from dropdown is ignored in payload and dropdown selection does not trigger edit mode
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
