### PR TITLE
JNG-6072 dialog from row lifecycle

### DIFF
--- a/judo-ui-react-itest/ActionGroupTest/action_group_test__god/src/test/resources/snapshots/frontend-react/src/dialogs/View/Galaxy/Stars/RelationViewPage/index.tsx.snapshot
+++ b/judo-ui-react-itest/ActionGroupTest/action_group_test__god/src/test/resources/snapshots/frontend-react/src/dialogs/View/Galaxy/Stars/RelationViewPage/index.tsx.snapshot
@@ -665,7 +665,12 @@ export default function ViewGalaxyStarsRelationViewPage(props: ViewGalaxyStarsRe
     if (rootPageId && dataPath && isDraft) {
       subscriptionRef.current = subscribe(`${rootPageId}:refreshed`, async (freshRootData: any) => {
         const copy = simpleCloneDeep(getValue<ViewStarStored>(freshRootData, dataPath!)!);
-        setData(copy);
+        if (copy !== undefined && copy !== null) {
+          // There are edge cases, e.g. when a row is opened in a dialog and an operation causes the row
+          // to be removed from the original table. In cases when the instance coming from a relation
+          // effectively gets removed we cannot null out our local data, because it results in the page crashing.
+          setData(copy);
+        }
       });
     }
 

--- a/judo-ui-react/src/main/resources/actor/src/dialogs/index.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/dialogs/index.tsx.hbs
@@ -387,7 +387,12 @@ export default function {{ pageName page }}(props: {{ pageName page }}Props) {
         if (rootPageId && dataPath && isDraft) {
           subscriptionRef.current = subscribe(`${rootPageId}:refreshed`, async (freshRootData: any) => {
             const copy = simpleCloneDeep(getValue<{{ dialogDataType page }}>(freshRootData, dataPath!)!);
-            setData(copy);
+            if (copy !== undefined && copy !== null) {
+              // There are edge cases, e.g. when a row is opened in a dialog and an operation causes the row
+              // to be removed from the original table. In cases when the instance coming from a relation
+              // effectively gets removed we cannot null out our local data, because it results in the page crashing.
+              setData(copy);
+            }
           });
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-6072" title="JNG-6072" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-6072</a>  Running operations in dialogs where dialogs have been opened from a table row cause UI to crash
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


- if a certain operation effectively removed the row from the table from which we opened it
- the operation caused the root page to reload
- the reload removed the element from the table
- the dialog got notified that it should reload
- the reload caused the re-calculation to yield either a different instance (tried to get the same row index from a new set, holy shit) or undefined because there were no rows left