### PR TITLE
JNG-6128 annotation based custom components

### DIFF
--- a/docs/pages/01_ui_react.adoc
+++ b/docs/pages/01_ui_react.adoc
@@ -516,7 +516,7 @@ Everything coming after the prefix will be utilized by the UI generator.
 If e.g. we would like to handle textareas with our custom `FancyText` component in
 multiple places of our application we should do the following:
 
-- Create the annotation `useFancyText` in our model
+- Create the annotation `useFancyText` in our model with class type: `hu.blackbelt.judo.meta.esm.ui.VisualElement`
 - Annotate every visual property with this where ever we would like to use FancyText
 - Check the "Custom Implementation" checkbox also everywhere where we placed the annotation
 

--- a/docs/pages/01_ui_react.adoc
+++ b/docs/pages/01_ui_react.adoc
@@ -499,6 +499,78 @@ class CustomL10NProvider implements L10NTranslationProvider {
 }
 ----
 
+=== Utilizing a single component declaration to handle multiple visual elements
+
+The framework supports modelers to declare any number of annotations with any names.
+
+The frontend generator can utilize these annotations to wire in custom components for
+visual elements with certain annotations.
+
+The modeler and developer should agree on an annotation prefix which is required by the
+generator to detect what to use for component wiring. This prefix is only relevant for the UI generator.
+
+Let's say the default is fine: `use` (if not, the generator can be configured via the `customComponentAnnotationPrefix` property).
+
+Everything coming after the prefix will be utilized by the UI generator.
+
+If e.g. we would like to handle textareas with our custom `FancyText` component in
+multiple places of our application we should do the following:
+
+- Create the annotation `useFancyText` in our model
+- Annotate every visual property with this where ever we would like to use FancyText
+- Check the "Custom Implementation" checkbox also everywhere where we placed the annotation
+
+Register our custom component which will handle the display logic for every annotated component:
+
+The registration **MUST** contain the `componentImplementation` configuration, in our case with the `FancyText` value.
+
+> The prefix is stripped internally in the generator and generated code-base.
+
+*application-customizer.tsx:*
+[source,typescriptjsx]
+----
+import type { BundleContext } from '@pandino/pandino-api';
+import { ApplicationCustomizer, AttributeBasedProxyProps, GenericProxyProps } from './interfaces';
+import { CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY } from './custom-element-types';
+import { ViewGalaxyStored } from '~/services/data-api/model/ViewGalaxy';
+import { ViewGalaxyViewActionDefinitions } from '~/containers/View/Galaxy/View/types';
+
+export class DefaultApplicationCustomizer implements ApplicationCustomizer {
+  async customize(context: BundleContext): Promise<void> {
+    context.registerService(CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY, FancyText, {
+      componentImplementation: 'FancyText',
+    });
+  }
+}
+
+const FancyText = ({ data, storeDiff, annotations, boundAttributeName }: GenericProxyProps<ViewGalaxyStored, ViewGalaxyViewActionDefinitions> & AttributeBasedProxyProps<ViewGalaxyStored>) => {
+  return (
+    <>
+      <p>{boundAttributeName} :: {JSON.stringify(annotations)}</p>
+      <textarea
+        style={{ width: '100%', color: 'pink' }}
+        rows={4}
+        name={'ohSoFancy'}
+        value={data[boundAttributeName] as string}
+        onChange={(evt) => storeDiff(boundAttributeName, evt.target.value) }
+      />
+    </>
+  );
+};
+----
+
+**Notes:**
+
+- `GenericProxyProps` can be defined with `<any, any>` of course to make it super generic
+- `AttributeBasedProxyProps` can also be defined with `<any>`
+- The `annotations` property will contain every annotation the captured component has
+- The `boundAttributeName` contains the property name in the owner payload which the `useFancyText` annotation has been
+  applied to
+- Defining multiple `use` annotations on the same visual property will yield chaotic results, it's not advised
+
+> The initially declared annotation `useFancyText` will be available as-is in the `annotations` list. The prefix
+  is not stripped here since the list contains actual modeled values.
+
 === Implementing a custom visual element
 
 Every Visual element implementation can be replaced by a custom one, given in the model the `customImplementation`

--- a/judo-ui-react-itest/ActionGroupTest/action_group_test__god/src/test/resources/snapshots/frontend-react/src/containers/Planet/View/PlanetViewPageContainer.tsx.snapshot
+++ b/judo-ui-react-itest/ActionGroupTest/action_group_test__god/src/test/resources/snapshots/frontend-react/src/containers/Planet/View/PlanetViewPageContainer.tsx.snapshot
@@ -152,6 +152,7 @@ export default function PlanetViewPage(props: PlanetViewPageProps) {
           submit={submit}
           isLoading={isLoading}
           actions={actions}
+          annotations={[]}
         >
           <div>{/* Placeholder */}</div>
         </ComponentProxy>

--- a/judo-ui-react-itest/ActionGroupTest/action_group_test__god/src/test/resources/snapshots/frontend-react/src/containers/View/Galaxy/Form/ViewGalaxyForm.tsx.snapshot
+++ b/judo-ui-react-itest/ActionGroupTest/action_group_test__god/src/test/resources/snapshots/frontend-react/src/containers/View/Galaxy/Form/ViewGalaxyForm.tsx.snapshot
@@ -399,6 +399,7 @@ export default function ViewGalaxyForm(props: ViewGalaxyFormProps) {
                   validationError={validation.get('astronomer')}
                   actions={actions}
                   submit={submit}
+                  annotations={[]}
                 />
               </Grid>
             </Grid>

--- a/judo-ui-react-itest/ActionGroupTest/action_group_test__god/src/test/resources/snapshots/frontend-react/src/containers/View/Galaxy/Form/ViewGalaxyFormDialogContainer.tsx.snapshot
+++ b/judo-ui-react-itest/ActionGroupTest/action_group_test__god/src/test/resources/snapshots/frontend-react/src/containers/View/Galaxy/Form/ViewGalaxyFormDialogContainer.tsx.snapshot
@@ -208,6 +208,7 @@ export default function ViewGalaxyFormDialog(props: ViewGalaxyFormDialogProps) {
           submit={submit}
           isLoading={isLoading}
           actions={actions}
+          annotations={[]}
         ></ComponentProxy>
       </DialogActions>
     </>

--- a/judo-ui-react-itest/ActionGroupTest/action_group_test__god/src/test/resources/snapshots/frontend-react/src/containers/View/Galaxy/View/ViewGalaxyView.tsx.snapshot
+++ b/judo-ui-react-itest/ActionGroupTest/action_group_test__god/src/test/resources/snapshots/frontend-react/src/containers/View/Galaxy/View/ViewGalaxyView.tsx.snapshot
@@ -172,6 +172,7 @@ export default function ViewGalaxyView(props: ViewGalaxyViewProps) {
                                         validationError={validation.get('stars')}
                                         refreshCounter={refreshCounter}
                                         isOwnerLoading={isLoading}
+                                        annotations={[]}
                                       />
                                     </Grid>
                                   </Grid>
@@ -487,6 +488,7 @@ export default function ViewGalaxyView(props: ViewGalaxyViewProps) {
                           storeDiff={storeDiff}
                           isLoading={isLoading}
                           actions={actions}
+                          annotations={[]}
                         >
                           <Card id="God/(esm/_0LmPoBMbEe2_DOUDKkB20Q)/GroupVisualElement" data-name="Discoverer">
                             <CardContent>
@@ -595,6 +597,7 @@ export default function ViewGalaxyView(props: ViewGalaxyViewProps) {
                                     validationError={validation.get('astronomer')}
                                     actions={actions}
                                     submit={submit}
+                                    annotations={[]}
                                   />
                                 </Grid>
                               </Grid>

--- a/judo-ui-react-itest/ActionGroupTest/action_group_test__god/src/test/resources/snapshots/frontend-react/src/containers/View/Galaxy/View/ViewGalaxyViewDialogContainer.tsx.snapshot
+++ b/judo-ui-react-itest/ActionGroupTest/action_group_test__god/src/test/resources/snapshots/frontend-react/src/containers/View/Galaxy/View/ViewGalaxyViewDialogContainer.tsx.snapshot
@@ -195,6 +195,7 @@ export default function ViewGalaxyViewDialog(props: ViewGalaxyViewDialogProps) {
           submit={submit}
           isLoading={isLoading}
           actions={actions}
+          annotations={[]}
         ></ComponentProxy>
       </DialogActions>
     </>

--- a/judo-ui-react-itest/ActionGroupTest/action_group_test__god/src/test/resources/snapshots/frontend-react/src/containers/View/Galaxy/View/ViewGalaxyViewPageContainer.tsx.snapshot
+++ b/judo-ui-react-itest/ActionGroupTest/action_group_test__god/src/test/resources/snapshots/frontend-react/src/containers/View/Galaxy/View/ViewGalaxyViewPageContainer.tsx.snapshot
@@ -152,6 +152,7 @@ export default function ViewGalaxyViewPage(props: ViewGalaxyViewPageProps) {
           submit={submit}
           isLoading={isLoading}
           actions={actions}
+          annotations={[]}
         >
           <div>{/* Placeholder */}</div>
         </ComponentProxy>

--- a/judo-ui-react-itest/ActionGroupTest/action_group_test__god/src/test/resources/snapshots/frontend-react/src/containers/View/Matter/Table/components/ViewMatterTableTableComponent/index.tsx.snapshot
+++ b/judo-ui-react-itest/ActionGroupTest/action_group_test__god/src/test/resources/snapshots/frontend-react/src/containers/View/Matter/Table/components/ViewMatterTableTableComponent/index.tsx.snapshot
@@ -95,7 +95,16 @@ export const filtersSerializer: FiltersSerializer = {
 // XMIID: God/(esm/_D04SgOq_EeuMzos2n42msw)/TransferObjectTableTable
 // Name: Table
 export function ViewMatterTableTableComponent(props: ViewMatterTableTableComponentProps) {
-  const { uniqueId, actions, dataPath, refreshCounter, isOwnerLoading, isDraft, validationError } = props;
+  const {
+    uniqueId,
+    actions,
+    dataPath,
+    refreshCounter,
+    isOwnerLoading,
+    isDraft,
+    validationError,
+    annotations = [],
+  } = props;
   const sidekickComponentFilter = `(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY})(component=${VIEW_MATTER_TABLE_TABLE_COMPONENT_SIDEKICK_COMPONENT_INTERFACE_KEY}))`;
 
   const { openConfirmDialog } = useConfirmDialog();

--- a/judo-ui-react-itest/ActionGroupTestPro/action_group_test_pro__god/src/test/resources/snapshots/frontend-react/src/components/table/EagerTable.tsx.snapshot
+++ b/judo-ui-react-itest/ActionGroupTestPro/action_group_test_pro__god/src/test/resources/snapshots/frontend-react/src/components/table/EagerTable.tsx.snapshot
@@ -89,6 +89,7 @@ interface EagerTableProps<T extends GridValidRowModel, TStored extends GridValid
   applyRowEdit?: (rowData: TStored) => Promise<any>;
   onRowEditCanceled?: (rowId: string) => void;
   actionsColumnWidth?: number;
+  annotations?: string[];
 }
 
 export function EagerTable<T extends GridValidRowModel, TStored extends T, S extends QueryCustomizer<T>>(
@@ -129,6 +130,7 @@ export function EagerTable<T extends GridValidRowModel, TStored extends T, S ext
     applyRowEdit,
     onRowEditCanceled,
     actionsColumnWidth,
+    annotations = [],
   } = props;
 
   const apiRef = useGridApiRef();
@@ -477,6 +479,8 @@ export function EagerTable<T extends GridValidRowModel, TStored extends T, S ext
         filterModel={filterModel}
         onFilterModelChange={handleFilterModelChange}
         data={data}
+        boundAttributeName={relationName}
+        annotations={annotations}
       />
       <StripedDataGrid
         apiRef={apiRef as unknown as any}

--- a/judo-ui-react-itest/ActionGroupTestPro/action_group_test_pro__god/src/test/resources/snapshots/frontend-react/src/components/table/LazyTable.tsx.snapshot
+++ b/judo-ui-react-itest/ActionGroupTestPro/action_group_test_pro__god/src/test/resources/snapshots/frontend-react/src/components/table/LazyTable.tsx.snapshot
@@ -118,6 +118,7 @@ interface LazyTableProps<T extends GridValidRowModel, TStored extends GridValidR
   applyRowEdit?: (rowData: TStored) => Promise<any>;
   onRowEditCanceled?: (rowId: string) => void;
   actionsColumnWidth?: number;
+  annotations?: string[];
 }
 
 export function LazyTable<T extends GridValidRowModel, TStored extends T, S extends QueryCustomizer<T>>(
@@ -166,6 +167,7 @@ export function LazyTable<T extends GridValidRowModel, TStored extends T, S exte
     applyRowEdit,
     onRowEditCanceled,
     actionsColumnWidth,
+    annotations = [],
   } = props;
 
   const apiRef = useGridApiRef();
@@ -655,6 +657,8 @@ export function LazyTable<T extends GridValidRowModel, TStored extends T, S exte
         filterModel={filterModel}
         onFilterModelChange={handleFilterModelChange}
         data={data}
+        boundAttributeName={relationName}
+        annotations={annotations}
       />
       <StripedDataGrid
         apiRef={apiRef as unknown as any}

--- a/judo-ui-react-itest/ActionGroupTestPro/action_group_test_pro__god/src/test/resources/snapshots/frontend-react/src/containers/View/Galaxy/Table/components/ViewGalaxyTableTableComponent/index.tsx.snapshot
+++ b/judo-ui-react-itest/ActionGroupTestPro/action_group_test_pro__god/src/test/resources/snapshots/frontend-react/src/containers/View/Galaxy/Table/components/ViewGalaxyTableTableComponent/index.tsx.snapshot
@@ -98,7 +98,16 @@ export const filtersSerializer: FiltersSerializer = {
 // XMIID: God/(esm/_YT0hQE7rEeycO-gUAWxcVg)/TransferObjectTableTable
 // Name: Table
 export function ViewGalaxyTableTableComponent(props: ViewGalaxyTableTableComponentProps) {
-  const { uniqueId, actions, dataPath, refreshCounter, isOwnerLoading, isDraft, validationError } = props;
+  const {
+    uniqueId,
+    actions,
+    dataPath,
+    refreshCounter,
+    isOwnerLoading,
+    isDraft,
+    validationError,
+    annotations = [],
+  } = props;
   const sidekickComponentFilter = `(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY})(component=${VIEW_GALAXY_TABLE_TABLE_COMPONENT_SIDEKICK_COMPONENT_INTERFACE_KEY}))`;
 
   const { openConfirmDialog } = useConfirmDialog();

--- a/judo-ui-react-itest/RelationTest/relation_test__actor/src/test/resources/snapshots/frontend-react/src/containers/TagContainerTransfer/TagContainerTransfer_View_Edit/components/TagContainerTransferTagContainerTransfer_View_EditManyAggregationCompostionComponent/index.tsx.snapshot
+++ b/judo-ui-react-itest/RelationTest/relation_test__actor/src/test/resources/snapshots/frontend-react/src/containers/TagContainerTransfer/TagContainerTransfer_View_Edit/components/TagContainerTransferTagContainerTransfer_View_EditManyAggregationCompostionComponent/index.tsx.snapshot
@@ -47,6 +47,7 @@ export function TagContainerTransferTagContainerTransfer_View_EditManyAggregatio
     isFormUpdateable,
     storeDiff,
     refreshCounter,
+    annotations = [],
   } = props;
 
   const { t } = useTranslation();

--- a/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/ReactStoredVariableHelper.java
+++ b/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/ReactStoredVariableHelper.java
@@ -74,6 +74,12 @@ public class ReactStoredVariableHelper extends StaticMethodValueResolver {
         }
     }
 
+    public static synchronized String getCustomComponentAnnotationPrefix() {
+        String prefix = (String) ThreadLocalContextHolder.getVariable("customComponentAnnotationPrefix");
+
+        return prefix == null ? "use" : prefix;
+    }
+
     public static synchronized Boolean isUseInlineColumnFilters() {
         if (!isMUILicensed()) {
             return false;

--- a/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/UiGeneralHelper.java
+++ b/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/UiGeneralHelper.java
@@ -24,14 +24,18 @@ import hu.blackbelt.judo.generator.commons.annotations.TemplateHelper;
 import hu.blackbelt.judo.meta.ui.Application;
 import hu.blackbelt.judo.meta.ui.NamedElement;
 import hu.blackbelt.judo.meta.ui.NavigationItem;
+import hu.blackbelt.judo.meta.ui.VisualElement;
 import hu.blackbelt.judo.meta.ui.data.*;
 import lombok.extern.java.Log;
 import org.eclipse.emf.ecore.EObject;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
+import static hu.blackbelt.judo.ui.generator.react.ReactStoredVariableHelper.getCustomComponentAnnotationPrefix;
+import static hu.blackbelt.judo.ui.generator.react.UiPandinoHelper.getCustomizationComponentInterfaceKey;
 import static hu.blackbelt.judo.ui.generator.typescript.rest.commons.UiCommonsHelper.getXMIID;
 import static java.util.Arrays.stream;
 
@@ -189,5 +193,43 @@ public class UiGeneralHelper {
 
     public static boolean elementHasAnnotation(NamedElement element, String annotation) {
         return element != null && element.getAnnotations().stream().anyMatch(a -> a.getName().equals(annotation));
+    }
+
+    public static boolean elementHasAnnotationStartingWith(NamedElement element, String prefix) {
+        return element != null && getAnnotationNameStartingWith(element, prefix) != null;
+    }
+
+    public static String getAnnotationNameStartingWith(NamedElement element, String prefix) {
+        if (element == null) {
+            return null;
+        }
+        return element.getAnnotations().stream()
+                .filter(a -> a.getName().startsWith(prefix))
+                .map(Annotation::getName)
+                .sorted()
+                .findFirst()
+                .orElse(null);
+    }
+
+    public static String attributeBasedComponentProxyFilters(VisualElement child) {
+        String annotationPrefix = getCustomComponentAnnotationPrefix();
+        // Direct component implementations will always take precedence.
+        String base = "(component=${" + getCustomizationComponentInterfaceKey(child) + "})";
+        if (elementHasAnnotationStartingWith(child, annotationPrefix)) {
+            // Or, if defined use a specific implementation
+            String full = getAnnotationNameStartingWith(child, annotationPrefix);
+            String parameterName = full.substring(annotationPrefix.length());
+            return "(|" + base + "(componentImplementation=" + parameterName + "))";
+        }
+        return base;
+    }
+
+    public static List<String> getAnnotationNamesForElement(NamedElement element) {
+        return element.getAnnotations().stream()
+                .map(Annotation::getName)
+                .collect(Collectors.toSet())
+                .stream()
+                .sorted()
+                .toList();
     }
 }

--- a/judo-ui-react/src/main/resources/actor/src/components-api/components/TrinaryLogic.ts.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components-api/components/TrinaryLogic.ts.hbs
@@ -20,4 +20,5 @@ export interface TrinaryLogicProps {
   helperText?: string | undefined;
   onChange?: (value: boolean | null) => void;
   className?: string | undefined;
+  annotations?: string[];
 }

--- a/judo-ui-react/src/main/resources/actor/src/components/table/EagerTable.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/table/EagerTable.tsx.hbs
@@ -97,6 +97,7 @@ interface EagerTableProps<T extends GridValidRowModel, TStored extends GridValid
   applyRowEdit?: (rowData: TStored) => Promise<any>;
   onRowEditCanceled?: (rowId: string) => void;
   actionsColumnWidth?: number;
+  annotations?: string[];
 }
 
 export function EagerTable<T extends GridValidRowModel, TStored extends T, S extends QueryCustomizer<T>>(props: EagerTableProps<T, TStored>) {
@@ -138,6 +139,7 @@ export function EagerTable<T extends GridValidRowModel, TStored extends T, S ext
     applyRowEdit,
     onRowEditCanceled,
     actionsColumnWidth,
+    annotations = [],
   } = props;
 
   const apiRef = useGridApiRef();
@@ -473,6 +475,8 @@ export function EagerTable<T extends GridValidRowModel, TStored extends T, S ext
           onFilterModelChange={handleFilterModelChange}
         {{/ if }}
         data={data}
+        boundAttributeName={relationName}
+        annotations={annotations}
       />
       <StripedDataGrid
         apiRef={apiRef as unknown as any}

--- a/judo-ui-react/src/main/resources/actor/src/components/table/LazyTable.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/table/LazyTable.tsx.hbs
@@ -109,6 +109,7 @@ interface LazyTableProps<T extends GridValidRowModel, TStored extends GridValidR
   applyRowEdit?: (rowData: TStored) => Promise<any>;
   onRowEditCanceled?: (rowId: string) => void;
   actionsColumnWidth?: number;
+  annotations?: string[];
 }
 
 export function LazyTable<T extends GridValidRowModel, TStored extends T, S extends QueryCustomizer<T>>(props: LazyTableProps<T, TStored>) {
@@ -158,6 +159,7 @@ export function LazyTable<T extends GridValidRowModel, TStored extends T, S exte
     applyRowEdit,
     onRowEditCanceled,
     actionsColumnWidth,
+    annotations = [],
   } = props;
 
   const apiRef = useGridApiRef();
@@ -629,6 +631,8 @@ export function LazyTable<T extends GridValidRowModel, TStored extends T, S exte
           onFilterModelChange={handleFilterModelChange}
         {{/ if }}
         data={data}
+        boundAttributeName={relationName}
+        annotations={annotations}
       />
       <StripedDataGrid
         apiRef={apiRef as unknown as any}

--- a/judo-ui-react/src/main/resources/actor/src/components/widgets/AssociationButton.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/widgets/AssociationButton.tsx.hbs
@@ -12,6 +12,7 @@ export interface AssociationBaseProps {
   variant?: 'text' | 'contained' | 'outlined';
   editMode?: boolean;
   children?: ReactNode;
+  annotations?: string[];
 }
 
 export interface AssociationButtonProps extends AssociationBaseProps {
@@ -29,6 +30,7 @@ export function AssociationButton({
   fetchCall,
   navigateAction,
   children,
+  annotations = [],
 }: AssociationButtonProps) {
   const { t } = useTranslation();
   const [data, setData] = useState<JudoIdentifiable<any> | null>(null);

--- a/judo-ui-react/src/main/resources/actor/src/components/widgets/BinaryInput.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/widgets/BinaryInput.tsx.hbs
@@ -30,6 +30,7 @@ export interface BinaryInputProps<P> {
     deleteCallback?: () => Promise<void>;
     icon?: string;
     mimeTypes?: MimeTypeDeclaration[];
+    annotations?: string[];
 }
 
 export function BinaryInput<P>(props: BinaryInputProps<P>) {

--- a/judo-ui-react/src/main/resources/actor/src/components/widgets/NumericInput.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/widgets/NumericInput.tsx.hbs
@@ -5,10 +5,11 @@ import { decimalSeparators, thousandSeparator } from '~/l10n/separators';
 
 export interface AdditionalNumericInputProps {
   formatValue?: boolean;
+  annotations?: string[];
 }
 
 export function NumericInput<BaseType = InputAttributes>(props: NumericFormatProps<BaseType> & AdditionalNumericInputProps) {
-  const { formatValue, ...rest } = props;
+  const { formatValue, annotations, ...rest } = props;
   const { locale: l10nLocale } = useL10N();
   const propsExpanded: NumericFormatProps<BaseType> = {
     decimalScale: 0,

--- a/judo-ui-react/src/main/resources/actor/src/components/widgets/SingleRelationInput.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/widgets/SingleRelationInput.tsx.hbs
@@ -45,6 +45,7 @@ interface SingleRelationInputProps<T> {
   refreshCounter?: number;
   isEager?: boolean;
   refreshAction?: () => Promise<T | null>;
+  annotations?: string[];
 }
 
 export const SingleRelationInput: FC<SingleRelationInputProps<any>> = <T,>({
@@ -67,6 +68,7 @@ export const SingleRelationInput: FC<SingleRelationInputProps<any>> = <T,>({
   buttonProps,
   refreshAction,
   refreshCounter,
+  annotations = [],
 }: SingleRelationInputProps<T>) => {
   const [options, setOptions] = useState<T[]>([]);
   const [loading, setLoading] = useState(false);

--- a/judo-ui-react/src/main/resources/actor/src/components/widgets/Tags.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/widgets/Tags.tsx.hbs
@@ -44,6 +44,7 @@ export interface TagsProps<P, T> {
   refreshCounter?: number;
   isOwnerLoading?: boolean;
   onAsyncLoad?: (queryCustomizer: QueryCustomizer<T>) => Promise<T[]>;
+  annotations?: string[];
 }
 
 /**
@@ -79,6 +80,7 @@ export function Tags<P, T>(props: TagsProps<P, T>) {
     refreshCounter,
     isOwnerLoading = false,
     onAsyncLoad,
+    annotations = [],
   } = props;
   const [options, setOptions] = useState<any[]>([]);
   const [loading, setLoading] = useState<boolean>(isOwnerLoading);

--- a/judo-ui-react/src/main/resources/actor/src/components/widgets/TextWithTypeAhead.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/widgets/TextWithTypeAhead.tsx.hbs
@@ -25,6 +25,7 @@ interface TextWithTypeAheadProps {
   onChange: (target?: string | null) => void;
   onBlur?: (event: any) => void;
   maxLength?: number;
+  annotations?: string[];
 }
 
 export const TextWithTypeAhead = ({
@@ -43,6 +44,7 @@ export const TextWithTypeAhead = ({
   onChange,
   onBlur,
   maxLength,
+  annotations = [],
 }: TextWithTypeAheadProps) => {
   const [options, setOptions] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);

--- a/judo-ui-react/src/main/resources/actor/src/components/widgets/TrinaryLogicCombobox.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/widgets/TrinaryLogicCombobox.tsx.hbs
@@ -23,6 +23,7 @@ export const TrinaryLogicCombobox = ({
   helperText,
   onChange,
   className,
+  annotations = [],
 }: TrinaryLogicProps) => {
   const { t } = useTranslation();
   const onChangeHandler = onChange

--- a/judo-ui-react/src/main/resources/actor/src/containers/components/cards/index.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/components/cards/index.tsx.hbs
@@ -123,6 +123,7 @@ export function {{ componentName table }}(props: {{ componentName table }}Props)
     editMode,
     isFormUpdateable,
     {{/ unless }}
+    annotations = [],
   } = props;
 
   const { openConfirmDialog } = useConfirmDialog();

--- a/judo-ui-react/src/main/resources/actor/src/containers/components/cards/types.ts.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/components/cards/types.ts.hbs
@@ -94,4 +94,5 @@ export interface {{ componentName table }}Props {
   processRowUpdate?: (newRow: GridRowModel) => void;
   ToolbarElement?: FC<ToolbarElementProps<{{ classDataName (getReferenceClassType table) 'Stored' }}>>;
   CardElement?: FC<CardProps<{{ classDataName (getReferenceClassType table) 'Stored' }}>>;
+  annotations?: string[];
 }

--- a/judo-ui-react/src/main/resources/actor/src/containers/components/link/index.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/components/link/index.tsx.hbs
@@ -22,7 +22,7 @@ import type { {{ componentName link }}ActionDefinitions, {{ componentName link }
 // XMIID: {{ getXMIID link }}
 // Name: {{ link.name }}
 export function {{ componentName link }}(props: {{ componentName link }}Props) {
-  const { ownerData, actions, dataPath, storeDiff, submit, validationError, disabled, readOnly, editMode, isLoading, isDraft{{# unless link.isEager }}, refreshCounter{{/ unless }} } = props;
+  const { ownerData, actions, dataPath, storeDiff, submit, validationError, disabled, readOnly, editMode, isLoading, isDraft{{# unless link.isEager }}, refreshCounter{{/ unless }}, annotations = [] } = props;
   const { t } = useTranslation();
 
   const isRequired = useMemo(() => {

--- a/judo-ui-react/src/main/resources/actor/src/containers/components/link/types.ts.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/components/link/types.ts.hbs
@@ -37,4 +37,5 @@ export interface {{ componentName link }}Props {
   {{# unless link.isEager }}
   refreshCounter: number;
   {{/ unless }}
+  annotations?: string[];
 }

--- a/judo-ui-react/src/main/resources/actor/src/containers/components/table/index.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/components/table/index.tsx.hbs
@@ -135,6 +135,7 @@ export function {{ componentName table }}(props: {{ componentName table }}Props)
     editMode,
     isFormUpdateable,
     {{/ unless }}
+    annotations = [],
   } = props;
   const sidekickComponentFilter = `(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY})(component=${ {{ camelCaseNameToInterfaceKey (componentName table) }}_SIDEKICK_COMPONENT_INTERFACE_KEY }))`;
 

--- a/judo-ui-react/src/main/resources/actor/src/containers/components/table/types.ts.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/components/table/types.ts.hbs
@@ -91,4 +91,5 @@ export interface {{ componentName table }}Props {
   handleRowModesModelChange?: (newRowModesModel: GridRowModesModel) => void;
   handleRowEditStop?: GridEventListener<'rowEditStop'>;
   processRowUpdate?: (newRow: GridRowModel) => void;
+  annotations?: string[];
 }

--- a/judo-ui-react/src/main/resources/actor/src/containers/components/tag/index.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/components/tag/index.tsx.hbs
@@ -45,6 +45,7 @@ export function {{ componentName table }}(props: {{ componentName table }}Props)
     isFormUpdateable,
     storeDiff,
     refreshCounter,
+    annotations = [],
   } = props;
 
   const { t } = useTranslation();

--- a/judo-ui-react/src/main/resources/actor/src/containers/components/tag/types.ts.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/components/tag/types.ts.hbs
@@ -77,4 +77,5 @@ export interface {{ componentName table }}Props {
   editMode: boolean;
   isFormUpdateable: () => boolean;
   storeDiff: (attributeName: keyof {{ classDataName container.dataElement '' }}, value: any) => void,
+  annotations?: string[];
 }

--- a/judo-ui-react/src/main/resources/actor/src/containers/dialog.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/dialog.tsx.hbs
@@ -187,6 +187,7 @@ export default function {{ containerComponentName container }}Dialog({{# unless 
                     {{/ if }}
                     isLoading={isLoading}
                     actions={actions}
+                    annotations={[{{# each (getAnnotationNamesForElement button) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
                   >
                 {{/ if }}
                 <LoadingButton
@@ -303,6 +304,7 @@ export default function {{ containerComponentName container }}Dialog({{# unless 
             {{/ if }}
             isLoading={isLoading}
             actions={actions}
+            annotations={[{{# each (getAnnotationNamesForElement container) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
           >
           </ComponentProxy>
         </DialogActions>

--- a/judo-ui-react/src/main/resources/actor/src/containers/page.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/page.tsx.hbs
@@ -81,6 +81,7 @@ export default function {{ containerComponentName container }}Page ({{# unless (
                     {{/ unless }}
                     isLoading={isLoading}
                     actions={actions}
+                    annotations={[{{# each (getAnnotationNamesForElement button) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
                   >
                 {{/ if }}
                 <LoadingButton
@@ -128,6 +129,7 @@ export default function {{ containerComponentName container }}Page ({{# unless (
             {{/ unless }}
             isLoading={isLoading}
             actions={actions}
+            annotations={[{{# each (getAnnotationNamesForElement container) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
           >
             <div>{/* Placeholder */}</div>
           </ComponentProxy>

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/binarytypeinput.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/binarytypeinput.hbs
@@ -5,13 +5,15 @@
     {{/ if }}
     {{# if child.customImplementation }}
         <ComponentProxy
-            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY})(component=${ {{~ getCustomizationComponentInterfaceKey child ~}} }))`}
+            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY}){{{ attributeBasedComponentProxyFilters child }}})`}
             data={data}
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
             isLoading={isLoading}
             actions={actions}
+            boundAttributeName={'{{ child.attributeType.name }}'}
+            annotations={[{{# each (getAnnotationNamesForElement child) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
         >
     {{/ if }}
     {{# if (hasTooltipText child) }}

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/button.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/button.hbs
@@ -12,6 +12,7 @@
       storeDiff={storeDiff}
       isLoading={isLoading}
       actions={actions}
+      annotations={[{{# each (getAnnotationNamesForElement child) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
     >
   {{/ if }}
   {{# or child.actionDefinition.isCallOperationAction child.actionDefinition.isOpenFormAction child.actionDefinition.isOpenSelectorAction }}

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/buttongroup.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/buttongroup.hbs
@@ -13,6 +13,7 @@
         storeDiff={storeDiff}
         isLoading={isLoading}
         actions={actions}
+        annotations={[{{# each (getAnnotationNamesForElement child) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
       >
     {{/ if }}
     {{# each (featuredButtonsForButtonGroup child) as |button| }}

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/checkbox.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/checkbox.hbs
@@ -5,13 +5,15 @@
     {{/ if }}
     {{# if child.customImplementation }}
         <ComponentProxy
-            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY})(component=${ {{~ getCustomizationComponentInterfaceKey child ~}} }))`}
+            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY}){{{ attributeBasedComponentProxyFilters child }}})`}
             data={data}
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
             isLoading={isLoading}
             actions={actions}
+            boundAttributeName={'{{ child.attributeType.name }}'}
+            annotations={[{{# each (getAnnotationNamesForElement child) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
         >
     {{/ if }}
         <FormControl error={!!validation.get('{{ child.attributeType.name }}')}>

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/dateinput.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/dateinput.hbs
@@ -5,13 +5,15 @@
     {{/ if }}
     {{# if child.customImplementation }}
         <ComponentProxy
-            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY})(component=${ {{~ getCustomizationComponentInterfaceKey child ~}} }))`}
+            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY}){{{ attributeBasedComponentProxyFilters child }}})`}
             data={data}
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
             isLoading={isLoading}
             actions={actions}
+            boundAttributeName={'{{ child.attributeType.name }}'}
+            annotations={[{{# each (getAnnotationNamesForElement child) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
         >
     {{/ if }}
     {{# if (hasTooltipText child) }}

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/datetimeinput.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/datetimeinput.hbs
@@ -5,13 +5,15 @@
     {{/ if }}
     {{# if child.customImplementation }}
         <ComponentProxy
-            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY})(component=${ {{~ getCustomizationComponentInterfaceKey child ~}} }))`}
+            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY}){{{ attributeBasedComponentProxyFilters child }}})`}
             data={data}
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
             isLoading={isLoading}
             actions={actions}
+            boundAttributeName={'{{ child.attributeType.name }}'}
+            annotations={[{{# each (getAnnotationNamesForElement child) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
         >
     {{/ if }}
     {{# if (hasTooltipText child) }}

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/divider.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/divider.hbs
@@ -12,6 +12,7 @@
             storeDiff={storeDiff}
             isLoading={isLoading}
             actions={actions}
+            annotations={[{{# each (getAnnotationNamesForElement child) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
         >
     {{/ if }}
     <Grid container sx={ { height: DIVIDER_HEIGHT } } alignItems="center">

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/enumerationcombo.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/enumerationcombo.hbs
@@ -5,13 +5,15 @@
     {{/ if }}
     {{# if child.customImplementation }}
         <ComponentProxy
-            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY})(component=${ {{~ getCustomizationComponentInterfaceKey child ~}} }))`}
+            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY}){{{ attributeBasedComponentProxyFilters child }}})`}
             data={data}
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
             isLoading={isLoading}
             actions={actions}
+            boundAttributeName={'{{ child.attributeType.name }}'}
+            annotations={[{{# each (getAnnotationNamesForElement child) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
         >
     {{/ if }}
     {{# if (hasTooltipText child) }}

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/enumerationradio.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/enumerationradio.hbs
@@ -5,13 +5,15 @@
     {{/ if }}
     {{# if child.customImplementation }}
         <ComponentProxy
-            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY})(component=${ {{~ getCustomizationComponentInterfaceKey child ~}} }))`}
+            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY}){{{ attributeBasedComponentProxyFilters child }}})`}
             data={data}
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
             isLoading={isLoading}
             actions={actions}
+            boundAttributeName={'{{ child.attributeType.name }}'}
+            annotations={[{{# each (getAnnotationNamesForElement child) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
         >
     {{/ if }}
     <FormControl

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/flex.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/flex.hbs
@@ -12,6 +12,7 @@
             storeDiff={storeDiff}
             isLoading={isLoading}
             actions={actions}
+            annotations={[{{# each (getAnnotationNamesForElement child) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
         >
     {{/ if }}
     {{# if this.card }}

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/formatted.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/formatted.hbs
@@ -5,13 +5,15 @@
     {{/ if }}
     {{# if child.customImplementation }}
         <ComponentProxy
-            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY})(component=${ {{~ getCustomizationComponentInterfaceKey child ~}} }))`}
+            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY}){{{ attributeBasedComponentProxyFilters child }}})`}
             data={data}
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
             isLoading={isLoading}
             actions={actions}
+            boundAttributeName={'{{ child.attributeType.name }}'}
+            annotations={[{{# each (getAnnotationNamesForElement child) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
         >
     {{/ if }}
     <Grid container direction="row" alignItems="center" {{# if child.icon }}spacing={2}{{/ if }}>

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/label.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/label.hbs
@@ -9,6 +9,7 @@
             storeDiff={storeDiff}
             isLoading={isLoading}
             actions={actions}
+            annotations={[{{# each (getAnnotationNamesForElement child) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
         >
     {{/ if }}
     <Grid container direction="row" alignItems="center" justifyContent="flex-start">

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/link.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/link.hbs
@@ -5,7 +5,7 @@
     {{/ if }}
     {{# if child.customImplementation }}
         <ComponentProxy
-            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY})(component=${ {{~ getCustomizationComponentInterfaceKey child ~}} }))`}
+            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY}){{{ attributeBasedComponentProxyFilters child }}})`}
             ownerData={data}
             data={ data?.{{ child.dataElement.name }} }
             disabled={ {{# if child.enabledBy }}!data.{{ child.enabledBy.name }} ||{{/ if }} {{ boolValue child.relationType.isReadOnly }} }
@@ -15,6 +15,8 @@
             actions={actions}
             isLoading={isLoading}
             isDraft={isDraft}
+            boundAttributeName={'{{ child.dataElement.name }}'}
+            annotations={[{{# each (getAnnotationNamesForElement child) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
         >
     {{/ if }}
     <{{ componentName child }}
@@ -32,6 +34,7 @@
         validationError={validation.get('{{ child.dataElement.name }}')}
         actions={actions}
         submit={submit}
+        annotations={[{{# each (getAnnotationNamesForElement child) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
     />
     {{# if child.customImplementation }}
         </ComponentProxy>

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/numericinput.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/numericinput.hbs
@@ -5,13 +5,15 @@
     {{/ if }}
     {{# if child.customImplementation }}
         <ComponentProxy
-            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY})(component=${ {{~ getCustomizationComponentInterfaceKey child ~}} }))`}
+            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY}){{{ attributeBasedComponentProxyFilters child }}})`}
             data={data}
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
             isLoading={isLoading}
             actions={actions}
+            boundAttributeName={'{{ child.attributeType.name }}'}
+            annotations={[{{# each (getAnnotationNamesForElement child) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
         >
     {{/ if }}
     {{# if (hasTooltipText child) }}

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/spacer.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/spacer.hbs
@@ -12,6 +12,7 @@
             storeDiff={storeDiff}
             isLoading={isLoading}
             actions={actions}
+            annotations={[{{# each (getAnnotationNamesForElement child) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
         >
     {{/ if }}
     <Grid container sx={ { height: DIVIDER_HEIGHT } } id="{{ getXMIID child }}"></Grid>

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/tabcontroller.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/tabcontroller.hbs
@@ -12,6 +12,7 @@
             storeDiff={storeDiff}
             isLoading={isLoading}
             actions={actions}
+            annotations={[{{# each (getAnnotationNamesForElement child) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
         >
     {{/ if }}
     <ModeledTabs

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/table.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/table.hbs
@@ -5,10 +5,12 @@
     {{/ if }}
     {{# if child.customImplementation }}
         <ComponentProxy
-            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY})(component=${ {{~ getCustomizationComponentInterfaceKey child ~}} }))`}
+            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY}){{{ attributeBasedComponentProxyFilters child }}})`}
             ownerData={data}
             isOwnerLoading={isLoading}
             actions={actions}
+            boundAttributeName={'{{ child.dataElement.name }}'}
+            annotations={[{{# each (getAnnotationNamesForElement child) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
             {{# unless container.table }}
               editMode={editMode}
               isFormUpdateable={isFormUpdateable}
@@ -55,6 +57,7 @@
                     {{/ unless }}
                     refreshCounter={refreshCounter}
                     isOwnerLoading={isLoading}
+                    annotations={[{{# each (getAnnotationNamesForElement child) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
                 />
                 {{ else }}
                 <{{ componentName child }}
@@ -69,6 +72,7 @@
                     isFormUpdateable={isFormUpdateable}
                     storeDiff={storeDiff}
                     refreshCounter={refreshCounter}
+                    annotations={[{{# each (getAnnotationNamesForElement child) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
                 />
                 {{/ unless }}
             </Grid>

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/text.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/text.hbs
@@ -12,6 +12,7 @@
             storeDiff={storeDiff}
             isLoading={isLoading}
             actions={actions}
+            annotations={[{{# each (getAnnotationNamesForElement child) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
         >
     {{/ if }}
     <Typography id="{{ getXMIID child }}">

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/textarea.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/textarea.hbs
@@ -5,13 +5,15 @@
     {{/ if }}
     {{# if child.customImplementation }}
         <ComponentProxy
-            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY})(component=${ {{~ getCustomizationComponentInterfaceKey child ~}} }))`}
+            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY}){{{ attributeBasedComponentProxyFilters child }}})`}
             data={data}
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
             isLoading={isLoading}
             actions={actions}
+            boundAttributeName={'{{ child.attributeType.name }}'}
+            annotations={[{{# each (getAnnotationNamesForElement child) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
         >
     {{/ if }}
     {{# if (hasTooltipText child) }}

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/textinput.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/textinput.hbs
@@ -5,13 +5,15 @@
     {{/ if }}
     {{# if child.customImplementation }}
         <ComponentProxy
-            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY})(component=${ {{~ getCustomizationComponentInterfaceKey child ~}} }))`}
+            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY}){{{ attributeBasedComponentProxyFilters child }}})`}
             data={data}
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
             isLoading={isLoading}
             actions={actions}
+            boundAttributeName={'{{ child.attributeType.name }}'}
+            annotations={[{{# each (getAnnotationNamesForElement child) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
         >
     {{/ if }}
     {{# if (hasTooltipText child) }}

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/timeinput.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/timeinput.hbs
@@ -5,13 +5,15 @@
     {{/ if }}
     {{# if child.customImplementation }}
         <ComponentProxy
-            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY})(component=${ {{~ getCustomizationComponentInterfaceKey child ~}} }))`}
+            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY}){{{ attributeBasedComponentProxyFilters child }}})`}
             data={data}
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
             isLoading={isLoading}
             actions={actions}
+            boundAttributeName={'{{ child.attributeType.name }}'}
+            annotations={[{{# each (getAnnotationNamesForElement child) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
         >
     {{/ if }}
     {{# if (hasTooltipText child) }}

--- a/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/trinarylogiccombo.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/widget-fragments/trinarylogiccombo.hbs
@@ -5,13 +5,15 @@
     {{/ if }}
     {{# if child.customImplementation }}
         <ComponentProxy
-            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY})(component=${ {{~ getCustomizationComponentInterfaceKey child ~}} }))`}
+            filter={`(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY}){{{ attributeBasedComponentProxyFilters child }}})`}
             data={data}
             validation={validation}
             editMode={editMode}
             storeDiff={storeDiff}
             isLoading={isLoading}
             actions={actions}
+            boundAttributeName={'{{ child.attributeType.name }}'}
+            annotations={[{{# each (getAnnotationNamesForElement child) as |annotation| }}'{{ annotation }}'{{# unless @last}},{{/ unless}}{{/ each }}]}
         >
     {{/ if }}
     {{# if (hasTooltipText child) }}

--- a/judo-ui-react/src/main/resources/actor/src/custom/interfaces.ts.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/custom/interfaces.ts.hbs
@@ -15,6 +15,11 @@ export interface GenericProxyProps<T, A> {
   actions: A;
 }
 
+export interface AttributeBasedProxyProps<T> {
+  annotations?: string;
+  boundAttributeName: keyof T;
+}
+
 export interface TableProxyProps<T, A> {
   ownerData: any;
   isOwnerLoading: boolean;

--- a/judo-ui-react/src/main/resources/actor/src/custom/interfaces.ts.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/custom/interfaces.ts.hbs
@@ -16,7 +16,7 @@ export interface GenericProxyProps<T, A> {
 }
 
 export interface AttributeBasedProxyProps<T> {
-  annotations?: string;
+  annotations?: string[];
   boundAttributeName: keyof T;
 }
 


### PR DESCRIPTION
**Explanation:**
For every visual property
- checked with "Custom Implementation"
- and having the annotation `useMermaid`

with a single component registration, we can achieve component re-use.

**Customization:**

```typescript
export class DefaultApplicationCustomizer implements ApplicationCustomizer {
  async customize(context: BundleContext): Promise<void> {
    // register your implementations here
    context.registerService(CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY, Mermaid, {
      componentImplementation: 'Mermaid',
    });
  }
}

const Mermaid = ({ data, storeDiff, annotations, boundAttributeName }: GenericProxyProps<ViewGalaxyStored, ViewGalaxyViewActionDefinitions> & AttributeBasedProxyProps<ViewGalaxyStored>) => {
  return (
    <>
      <p>{boundAttributeName} :: {JSON.stringify(annotations)}</p>
      <textarea
        style={{ width: '100%' }}
        rows={4}
        name={'hello'}
        value={data[boundAttributeName] as string}
        onChange={(evt) => storeDiff(boundAttributeName, evt.target.value)}
      />
    </>
  );
};
```

**Before:**

![image](https://github.com/user-attachments/assets/4dc6265d-ffac-41b2-9ae0-18d1c642df9c)

**After:**

![image](https://github.com/user-attachments/assets/212551d6-be80-4c70-aaf4-b5f3e8afcd3b)
