### PR TITLE
JNG-6379 improve build performance

### DIFF
--- a/judo-ui-react/.settings/org.eclipse.jdt.apt.core.prefs
+++ b/judo-ui-react/.settings/org.eclipse.jdt.apt.core.prefs
@@ -1,0 +1,4 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.apt.aptEnabled=true
+org.eclipse.jdt.apt.genSrcDir=target/generated-sources/annotations
+org.eclipse.jdt.apt.genTestSrcDir=target/generated-test-sources/test-annotations

--- a/judo-ui-react/src/main/resources/actor/package.json.dependencies.fragment.hbs
+++ b/judo-ui-react/src/main/resources/actor/package.json.dependencies.fragment.hbs
@@ -12,9 +12,9 @@
 "@mui/x-date-pickers{{ getMUIPickersPlanSuffix }}": "8.23.0",
 "@mui/x-tree-view": "8.23.0",
 {{# if isMUILicensed }}"@mui/x-license": "8.23.0",{{/ if }}
-"@pandino/loader-configuration-dom": "0.8.29",
-"@pandino/pandino": "0.8.29",
-"@pandino/react-hooks": "0.8.29",
+"@pandino/loader-configuration-dom": "0.8.32",
+"@pandino/pandino": "0.8.32",
+"@pandino/react-hooks": "0.8.32",
 "antlr4ng": "3.0.16",
 "axios": "1.13.2",
 "clsx": "2.1.1",

--- a/judo-ui-react/src/main/resources/actor/package.json.dependencies.fragment.hbs
+++ b/judo-ui-react/src/main/resources/actor/package.json.dependencies.fragment.hbs
@@ -12,9 +12,9 @@
 "@mui/x-date-pickers{{ getMUIPickersPlanSuffix }}": "8.23.0",
 "@mui/x-tree-view": "8.23.0",
 {{# if isMUILicensed }}"@mui/x-license": "8.23.0",{{/ if }}
-"@pandino/loader-configuration-dom": "0.8.32",
-"@pandino/pandino": "0.8.32",
-"@pandino/react-hooks": "0.8.32",
+"@pandino/loader-configuration-dom": "0.8.33",
+"@pandino/pandino": "0.8.33",
+"@pandino/react-hooks": "0.8.33",
 "antlr4ng": "3.0.16",
 "axios": "1.13.2",
 "clsx": "2.1.1",

--- a/judo-ui-react/src/main/resources/actor/package.json.dev-dependencies.fragment.hbs
+++ b/judo-ui-react/src/main/resources/actor/package.json.dev-dependencies.fragment.hbs
@@ -1,5 +1,5 @@
 "@biomejs/biome": "2.3.11",
-"@pandino/pandino-api": "0.8.32",
+"@pandino/pandino-api": "0.8.33",
 "@typescript/native-preview": "latest",
 "@types/node": "22.19.3",
 "@types/nprogress": "0.2.3",

--- a/judo-ui-react/src/main/resources/actor/package.json.dev-dependencies.fragment.hbs
+++ b/judo-ui-react/src/main/resources/actor/package.json.dev-dependencies.fragment.hbs
@@ -1,5 +1,5 @@
 "@biomejs/biome": "2.3.11",
-"@pandino/pandino-api": "0.8.29",
+"@pandino/pandino-api": "0.8.32",
 "@typescript/native-preview": "latest",
 "@types/node": "22.19.3",
 "@types/nprogress": "0.2.3",

--- a/judo-ui-react/src/main/resources/actor/package.json.dev-dependencies.fragment.hbs
+++ b/judo-ui-react/src/main/resources/actor/package.json.dev-dependencies.fragment.hbs
@@ -1,5 +1,6 @@
 "@biomejs/biome": "2.3.11",
 "@pandino/pandino-api": "0.8.29",
+"@typescript/native-preview": "latest",
 "@types/node": "22.19.3",
 "@types/nprogress": "0.2.3",
 "@types/react": "19.2.7",
@@ -7,6 +8,7 @@
 "@types/uuid": "11.0.0",
 "@vitejs/plugin-react": "5.1.2",
 "babel-plugin-react-compiler": "1.0.0",
+"lightningcss": "1.29.3",
 "typescript": "5.9.3",
-"vite": "7.3.0",
+"vite": "npm:rolldown-vite@7.3.1",
 "vitest": "4.0.16"

--- a/judo-ui-react/src/main/resources/actor/package.json.scripts.fragment.hbs
+++ b/judo-ui-react/src/main/resources/actor/package.json.scripts.fragment.hbs
@@ -1,6 +1,6 @@
 "dev": "vite",
 "build:reckless": "vite build",
-"build": "tsc && vite build",
+"build": "tsgo && vite build",
 "preview": "vite preview",
 "test:dev": "vitest",
 "test": "vitest run",

--- a/judo-ui-react/src/main/resources/actor/src/theme/typography.ts.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/theme/typography.ts.hbs
@@ -1,6 +1,6 @@
 {{> fragment.header.hbs }}
 
-import type { TypographyVariantsOptions } from "@mui/material/styles/createTypography";
+import type { TypographyVariantsOptions } from "@mui/material/styles";
 import { createTheme } from '@mui/material/styles';
 const { breakpoints } = createTheme(); // yields the same `breakpoints` helper
 import { density } from './density';

--- a/judo-ui-react/src/main/resources/actor/tsconfig.json
+++ b/judo-ui-react/src/main/resources/actor/tsconfig.json
@@ -10,7 +10,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "incremental": true,
     "isolatedModules": true,
@@ -19,6 +19,10 @@
     "jsx": "react-jsx",
     "paths": {
       "~/*": ["./src/*"],
+      "@pandino/pandino-api": ["./node_modules/@pandino/pandino-api/dist/esm/dist"],
+      "@pandino/react-hooks": ["./node_modules/@pandino/react-hooks/dist/esm/dist"],
+      "@pandino/pandino": ["./node_modules/@pandino/pandino/dist/esm/dist"],
+      "@pandino/loader-configuration-dom": ["./node_modules/@pandino/loader-configuration-dom/dist/esm/dist"]
     }
   },
   "include": [

--- a/judo-ui-react/src/main/resources/actor/tsconfig.json
+++ b/judo-ui-react/src/main/resources/actor/tsconfig.json
@@ -18,11 +18,7 @@
     "strictFunctionTypes": true,
     "jsx": "react-jsx",
     "paths": {
-      "~/*": ["./src/*"],
-      "@pandino/pandino-api": ["./node_modules/@pandino/pandino-api/dist/esm/dist"],
-      "@pandino/react-hooks": ["./node_modules/@pandino/react-hooks/dist/esm/dist"],
-      "@pandino/pandino": ["./node_modules/@pandino/pandino/dist/esm/dist"],
-      "@pandino/loader-configuration-dom": ["./node_modules/@pandino/loader-configuration-dom/dist/esm/dist"]
+      "~/*": ["./src/*"]
     }
   },
   "include": [

--- a/judo-ui-react/src/main/resources/actor/tsconfig.node.json
+++ b/judo-ui-react/src/main/resources/actor/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": [

--- a/judo-ui-react/src/main/resources/actor/vite.config.ts.hbs
+++ b/judo-ui-react/src/main/resources/actor/vite.config.ts.hbs
@@ -10,18 +10,29 @@ export default defineConfig(({ mode }) => ({
       { find: '~', replacement: path.resolve(__dirname, 'src') },
     ],
   },
+  css: {
+    transformer: 'lightningcss',
+    lightningcss: {
+      drafts: {
+        customMedia: true,
+      },
+    },
+  },
   build: {
+    cssMinify: 'lightningcss',
     rollupOptions: {
       output: {
-        manualChunks: {
-          'antlr4ng': ['antlr4ng'],
-          'pandino': ['@pandino/pandino', '@pandino/react-hooks'],
-          'i18next': ['react-i18next', 'i18next'],
-          'react': ['react-dom', 'react'],
-          'react-router': ['react-router-dom', 'react-router'],
-          '@mui/material': ['@mui/material'],
-          '@mui/x-data-grid{{ getMUIDataGridPlanSuffix }}': ['@mui/x-data-grid{{ getMUIDataGridPlanSuffix }}'],
-          '@mui/x-date-pickers{{ getMUIPickersPlanSuffix }}': ['@mui/x-date-pickers{{ getMUIPickersPlanSuffix }}'],
+        advancedChunks: {
+          groups: [
+            { name: 'antlr4ng', test: /[\\/]node_modules[\\/]antlr4ng[\\/]/ },
+            { name: 'pandino', test: /[\\/]node_modules[\\/]@pandino[\\/]/ },
+            { name: 'i18next', test: /[\\/]node_modules[\\/](react-i18next|i18next)[\\/]/ },
+            { name: 'react', test: /[\\/]node_modules[\\/]react(-dom)?[\\/]/ },
+            { name: 'react-router', test: /[\\/]node_modules[\\/]react-router(-dom)?[\\/]/ },
+            { name: 'mui-material', test: /[\\/]node_modules[\\/]@mui[\\/]material[\\/]/ },
+            { name: 'mui-x-data-grid', test: /[\\/]node_modules[\\/]@mui[\\/]x-data-grid/ },
+            { name: 'mui-x-date-pickers', test: /[\\/]node_modules[\\/]@mui[\\/]x-date-pickers/ },
+          ],
         },
       },
     },

--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
         <maven-enforcer-plugin-version>3.3.0</maven-enforcer-plugin-version>
         <enforcer-checkfile-rules-version>1.0.0.20250606_062313_a9cd262e_develop</enforcer-checkfile-rules-version>
 
-        <node-version>22.11.0</node-version>
-        <pnpm-version>9.12.3</pnpm-version>
+        <node-version>22.14.0</node-version>
+        <pnpm-version>9.15.9</pnpm-version>
 
         <judo-meta-ui-version>1.1.0.20260202_144548_0fc3c7ef_develop</judo-meta-ui-version>
         <judo-generator-commons-version>1.0.0.20251205_002803_8f2ad582_develop</judo-generator-commons-version>


### PR DESCRIPTION
Not all libs are production ready yet. FYI.

Run | develop (baseline) | migration branch | delta
-- | -- | -- | --
Run 1 | 37.82s | 25.02s |  
Run 2 | 38.89s | 23.12s |  
Run 3 | 38.59s | 22.86s |  
Avg module | 38.43s | 23.67s | -38.4%
Avg total | 45.07s | 30.23s | -32.9%

- Swapped esbuild to Rolldown including not only Vite but Vitest as well
- Added lightningcss for css
- swapped out tsc to tsgo

