### PR TITLE
JNG-6370 FIX: FAB component on mobile

### DIFF
--- a/judo-ui-react/src/main/resources/actor/tsconfig.json
+++ b/judo-ui-react/src/main/resources/actor/tsconfig.json
@@ -5,7 +5,6 @@
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
     "skipLibCheck": true,
-    "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Remove esModuleInterop: false from tsconfig.json template because TypeScript 5.9.3 (used by the project) no longer supports esModuleInterop=false and throws TS5108. The allowSyntheticDefaultImports: true already covers the intended behavior. 