### PR TITLE
JNG-6399 Honor Table.checkboxSelection mode (ENABLED / DISABLED / AUTO)

### DIFF
--- a/judo-ui-react-itest/ActionGroupTest/action_group_test__god/src/test/resources/snapshots/frontend-react/src/containers/View/Matter/Table/components/ViewMatterTableTableComponent/index.tsx.snapshot
+++ b/judo-ui-react-itest/ActionGroupTest/action_group_test__god/src/test/resources/snapshots/frontend-react/src/containers/View/Matter/Table/components/ViewMatterTableTableComponent/index.tsx.snapshot
@@ -488,6 +488,7 @@ export function ViewMatterTableTableComponent(props: ViewMatterTableTableCompone
         validationError={validationError}
         actions={actions}
         allowSelectMultiple={allowSelectMultiple}
+        checkboxSelection={isSelector ? true : true}
         dataElementId={'God/(esm/_D0eC0Oq_EeuMzos2n42msw)/ClassType'}
         crudOperationsDisplayed={1}
         transferOperationsDisplayed={0}

--- a/judo-ui-react-itest/ActionGroupTestPro/action_group_test_pro__god/src/test/resources/snapshots/frontend-react/src/components/table/EagerTable.tsx.snapshot
+++ b/judo-ui-react-itest/ActionGroupTestPro/action_group_test_pro__god/src/test/resources/snapshots/frontend-react/src/components/table/EagerTable.tsx.snapshot
@@ -638,10 +638,22 @@ export function EagerTable<T extends GridValidRowModel, TStored extends T, S ext
                               actions[toolBarAction.name]!(processedQueryCustomizer);
                             } else {
                               if (toolBarAction.isBulk) {
-                                const { result: bulkResult } = await actions[toolBarAction.name]!(selectedRows.current);
-                                const reason: DialogResultReason = bulkResult;
-                                if (reason === 'submit' || reason === 'delete') {
-                                  handleOnSelection(createEmptySelectionModel()); // not resetting on refreshes because refreshes would always remove selections...
+                                if (toolBarAction.bulkFromRowAction) {
+                                  // Implicit bulk toolbar entry derived from a batchable row action.
+                                  // Fan out the per-row action across the selection sequentially.
+
+                                  for (const row of selectedRows.current) {
+                                    await actions[toolBarAction.name]!(row);
+                                  }
+                                  handleOnSelection(createEmptySelectionModel());
+                                } else {
+                                  const { result: bulkResult } = await actions[toolBarAction.name]!(
+                                    selectedRows.current,
+                                  );
+                                  const reason: DialogResultReason = bulkResult;
+                                  if (reason === 'submit' || reason === 'delete') {
+                                    handleOnSelection(createEmptySelectionModel()); // not resetting on refreshes because refreshes would always remove selections...
+                                  }
                                 }
                               } else {
                                 if (toolBarAction.name === calculateActionName(relationName, 'clearAction')) {

--- a/judo-ui-react-itest/ActionGroupTestPro/action_group_test_pro__god/src/test/resources/snapshots/frontend-react/src/components/table/LazyTable.tsx.snapshot
+++ b/judo-ui-react-itest/ActionGroupTestPro/action_group_test_pro__god/src/test/resources/snapshots/frontend-react/src/components/table/LazyTable.tsx.snapshot
@@ -812,10 +812,22 @@ export function LazyTable<T extends GridValidRowModel, TStored extends T, S exte
                               actions[toolBarAction.name]!(processedQueryCustomizer);
                             } else {
                               if (toolBarAction.isBulk) {
-                                const { result: bulkResult } = await actions[toolBarAction.name]!(selectedRows.current);
-                                const reason: DialogResultReason = bulkResult;
-                                if (reason === 'submit' || reason === 'delete') {
-                                  handleOnSelection([]); // not resetting on refreshes because refreshes would always remove selections...
+                                if (toolBarAction.bulkFromRowAction) {
+                                  // Implicit bulk toolbar entry derived from a batchable row action.
+                                  // Fan out the per-row action across the selection sequentially.
+
+                                  for (const row of selectedRows.current) {
+                                    await actions[toolBarAction.name]!(row);
+                                  }
+                                  handleOnSelection([]);
+                                } else {
+                                  const { result: bulkResult } = await actions[toolBarAction.name]!(
+                                    selectedRows.current,
+                                  );
+                                  const reason: DialogResultReason = bulkResult;
+                                  if (reason === 'submit' || reason === 'delete') {
+                                    handleOnSelection([]); // not resetting on refreshes because refreshes would always remove selections...
+                                  }
                                 }
                               } else {
                                 if (toolBarAction.name === calculateActionName(relationName, 'clearAction')) {

--- a/judo-ui-react-itest/ActionGroupTestPro/action_group_test_pro__god/src/test/resources/snapshots/frontend-react/src/containers/View/Galaxy/Table/components/ViewGalaxyTableTableComponent/index.tsx.snapshot
+++ b/judo-ui-react-itest/ActionGroupTestPro/action_group_test_pro__god/src/test/resources/snapshots/frontend-react/src/containers/View/Galaxy/Table/components/ViewGalaxyTableTableComponent/index.tsx.snapshot
@@ -789,6 +789,7 @@ export function ViewGalaxyTableTableComponent(props: ViewGalaxyTableTableCompone
         validationError={validationError}
         actions={actions}
         allowSelectMultiple={allowSelectMultiple}
+        checkboxSelection={isSelector ? true : true}
         dataElementId={'God/(esm/_YTkpoE7rEeycO-gUAWxcVg)/ClassType'}
         crudOperationsDisplayed={1}
         transferOperationsDisplayed={0}

--- a/judo-ui-react-itest/RelationTest/relation_test__actor/src/test/resources/snapshots/frontend-react/src/containers/TagContainerTransfer/TagContainerTransfer_View_Edit/components/TagContainerTransferTagContainerTransfer_View_EditManyAggregationCompostionComponent/index.tsx.snapshot
+++ b/judo-ui-react-itest/RelationTest/relation_test__actor/src/test/resources/snapshots/frontend-react/src/containers/TagContainerTransfer/TagContainerTransfer_View_Edit/components/TagContainerTransferTagContainerTransfer_View_EditManyAggregationCompostionComponent/index.tsx.snapshot
@@ -48,7 +48,7 @@ export function TagContainerTransferTagContainerTransfer_View_EditManyAggregatio
     storeDiff,
     refreshCounter,
     annotations = [],
-    allowSelectMultiple,
+    allowSelectMultiple = true,
   } = props;
 
   const { t } = useTranslation();

--- a/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/UiTableHelper.java
+++ b/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/UiTableHelper.java
@@ -370,8 +370,102 @@ public class UiTableHelper {
                 .toList();
     }
 
-    public static boolean checkboxSelectionEnabled(Table table) {
-        return table.getCheckboxSelection() == null || table.getCheckboxSelection() != CheckboxSelection.DISABLED;
+    /**
+     * True iff the table has at least one table-level bulk action button.
+     * The closed list of bulk action definitions:
+     *   - BulkDeleteActionDefinition
+     *   - BulkRemoveActionDefinition
+     *   - BulkCallOperationActionDefinition
+     */
+    public static boolean tableHasAnyBulkAction(Table table) {
+        if (table == null || table.getTableActionButtonGroup() == null) {
+            return false;
+        }
+        return table.getTableActionButtonGroup().getButtons().stream()
+                .map(Button::getActionDefinition)
+                .filter(Objects::nonNull)
+                .anyMatch(ad -> ad.getIsBulkDeleteAction()
+                             || ad.getIsBulkRemoveAction()
+                             || ad.getIsBulkCallOperationAction());
+    }
+
+    /**
+     * True iff the given action definition is "batchable" — i.e. can be invoked safely
+     * on N selected rows without per-row user input.
+     *
+     * Batchable action definitions (closed list):
+     *   - RowDeleteActionDefinition
+     *   - ParameterlessCallOperationActionDefinition
+     */
+    public static boolean isRowActionBatchable(ActionDefinition ad) {
+        if (ad == null) {
+            return false;
+        }
+        return ad.getIsRowDeleteAction() || ad.getIsParameterlessCallOperationAction();
+    }
+
+    /**
+     * STRICT variant: true iff the table has at least one batchable row action AND
+     * zero input-needing row actions in {@code rowActionButtonGroup}.
+     *
+     * Categories (closed list):
+     *   Batchable      = RowDeleteActionDefinition, ParameterlessCallOperationActionDefinition
+     *   Input-needing  = InputFormCallOperationActionDefinition, InputSelectorCallOperationActionDefinition  (VETO)
+     *   Neutral        = everything else (e.g. OpenPage / OpenForm — single-row navigation)
+     *
+     * A single input-needing row action vetoes the result, even if batchable actions also exist.
+     */
+    public static boolean tableHasAnyBatchableRowAction(Table table) {
+        if (table == null || table.getRowActionButtonGroup() == null) {
+            return false;
+        }
+        boolean hasBatchable = false;
+        for (Button button : table.getRowActionButtonGroup().getButtons()) {
+            ActionDefinition ad = button.getActionDefinition();
+            if (ad == null) {
+                continue;
+            }
+            if (ad.getIsInputFormCallOperationAction() || ad.getIsInputSelectorCallOperationAction()) {
+                return false; // veto
+            }
+            if (isRowActionBatchable(ad)) {
+                hasBatchable = true;
+            }
+        }
+        return hasBatchable;
+    }
+
+    /**
+     * True iff the checkbox column should render when this table is on its own page.
+     *   ENABLED / null  -> true
+     *   DISABLED        -> false
+     *   AUTO            -> tableHasAnyBulkAction(table) || tableHasAnyBatchableRowAction(table)
+     *
+     * Selector-mode rendering is the template's responsibility (runtime `isSelector` flag);
+     * this helper computes only the own-page side.
+     */
+    public static boolean checkboxSelectionForOwnPage(Table table) {
+        if (table == null) {
+            return true;
+        }
+        CheckboxSelection cb = table.getCheckboxSelection();
+        if (cb == CheckboxSelection.DISABLED) {
+            return false;
+        }
+        if (cb == CheckboxSelection.AUTO) {
+            return tableHasAnyBulkAction(table) || tableHasAnyBatchableRowAction(table);
+        }
+        return true; // ENABLED or null
+    }
+
+    /**
+     * True iff multi-row select should be allowed when this table is on its own page.
+     * Mirrors {@link #checkboxSelectionForOwnPage} exactly today. Kept as a separate
+     * method so a future divergence (e.g. "AUTO shows column but disallows multi")
+     * doesn't require renaming.
+     */
+    public static boolean multiSelectAllowedForOwnPage(Table table) {
+        return checkboxSelectionForOwnPage(table);
     }
 
     public static boolean isTableTag(Table table) {

--- a/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/UiWidgetHelper.java
+++ b/judo-ui-react/src/main/java/hu/blackbelt/judo/ui/generator/react/UiWidgetHelper.java
@@ -377,6 +377,17 @@ public class UiWidgetHelper {
     }
 
     public static String tableButtonVisibilityConditions(Button button, Table table, PageContainer container) {
+        // When the modeler picked checkboxSelection=DISABLED (or AUTO on a bulk-less table),
+        // the toolbar entries for bulk actions must be hidden because there is no way to build
+        // a selection without the checkbox column. Collapse the visibility expression to the
+        // literal `false` so the generated `enabled:` callback evaluates to false.
+
+        if (button.getActionDefinition() != null
+                && button.getActionDefinition().isIsBulk()
+                && !UiTableHelper.multiSelectAllowedForOwnPage(table)) {
+            return "false";
+        }
+
         String result = "";
 
         if (table.getEnabledBy() != null) {

--- a/judo-ui-react/src/main/resources/actor/src/components/table/EagerTable.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/table/EagerTable.tsx.hbs
@@ -631,10 +631,20 @@ export function EagerTable<T extends GridValidRowModel, TStored extends T, S ext
                               actions[toolBarAction.name]!(processedQueryCustomizer);
                             } else {
                               if (toolBarAction.isBulk) {
-                                const { result: bulkResult } = await actions[toolBarAction.name]!(selectedRows.current);
-                                const reason: DialogResultReason = bulkResult;
-                                if (reason === 'submit' || reason === 'delete') {
-                                  handleOnSelection(createEmptySelectionModel()); // not resetting on refreshes because refreshes would always remove selections...
+                                if (toolBarAction.bulkFromRowAction) {
+                                  // Implicit bulk toolbar entry derived from a batchable row action.
+                                  // Fan out the per-row action across the selection sequentially.
+
+                                  for (const row of selectedRows.current) {
+                                    await actions[toolBarAction.name]!(row);
+                                  }
+                                  handleOnSelection(createEmptySelectionModel());
+                                } else {
+                                  const { result: bulkResult } = await actions[toolBarAction.name]!(selectedRows.current);
+                                  const reason: DialogResultReason = bulkResult;
+                                  if (reason === 'submit' || reason === 'delete') {
+                                    handleOnSelection(createEmptySelectionModel()); // not resetting on refreshes because refreshes would always remove selections...
+                                  }
                                 }
                               } else {
                                 if (toolBarAction.name === calculateActionName(relationName, 'clearAction')) {

--- a/judo-ui-react/src/main/resources/actor/src/components/table/LazyTable.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/components/table/LazyTable.tsx.hbs
@@ -796,10 +796,20 @@ export function LazyTable<T extends GridValidRowModel, TStored extends T, S exte
                               actions[toolBarAction.name]!(processedQueryCustomizer);
                             } else {
                               if (toolBarAction.isBulk) {
-                                const { result: bulkResult } = await actions[toolBarAction.name]!(selectedRows.current);
-                                const reason: DialogResultReason = bulkResult;
-                                if (reason === 'submit' || reason === 'delete') {
-                                  handleOnSelection([]); // not resetting on refreshes because refreshes would always remove selections...
+                                if (toolBarAction.bulkFromRowAction) {
+                                  // Implicit bulk toolbar entry derived from a batchable row action.
+                                  // Fan out the per-row action across the selection sequentially.
+
+                                  for (const row of selectedRows.current) {
+                                    await actions[toolBarAction.name]!(row);
+                                  }
+                                  handleOnSelection([]);
+                                } else {
+                                  const { result: bulkResult } = await actions[toolBarAction.name]!(selectedRows.current);
+                                  const reason: DialogResultReason = bulkResult;
+                                  if (reason === 'submit' || reason === 'delete') {
+                                    handleOnSelection([]); // not resetting on refreshes because refreshes would always remove selections...
+                                  }
                                 }
                               } else {
                                 if (toolBarAction.name === calculateActionName(relationName, 'clearAction')) {

--- a/judo-ui-react/src/main/resources/actor/src/containers/components/cards/index.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/components/cards/index.tsx.hbs
@@ -120,7 +120,7 @@ export function {{ componentName table }}(props: {{ componentName table }}Props)
     isFormUpdateable,
     {{/ unless }}
     annotations = [],
-    allowSelectMultiple,
+    allowSelectMultiple = {{ boolValue (multiSelectAllowedForOwnPage table) }},
   } = props;
 
   const { openConfirmDialog } = useConfirmDialog();

--- a/judo-ui-react/src/main/resources/actor/src/containers/components/table/index.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/components/table/index.tsx.hbs
@@ -134,7 +134,7 @@ export function {{ componentName table }}(props: {{ componentName table }}Props)
     isFormUpdateable,
     {{/ unless }}
     annotations = [],
-    allowSelectMultiple = true,
+    allowSelectMultiple = {{ boolValue (multiSelectAllowedForOwnPage table) }},
   } = props;
   const sidekickComponentFilter = `(&(${OBJECTCLASS}=${CUSTOM_VISUAL_ELEMENT_INTERFACE_KEY})(component=${ {{ camelCaseNameToInterfaceKey (componentName table) }}_SIDEKICK_COMPONENT_INTERFACE_KEY }))`;
 
@@ -236,7 +236,30 @@ export function {{ componentName table }}(props: {{ componentName table }}Props)
       {{/ if }}
     },
     {{/ each }}
+    {{!-- Implicit bulk toolbar entries for batchable row actions, emitted when AUTO
+         was granted by the row-action path (i.e. no explicit BulkX exists on this table). --}}
 
+    {{# if (tableHasAnyBatchableRowAction table) }}
+    {{# unless (tableHasAnyBulkAction table) }}
+    {{# each table.rowActionButtonGroup.buttons as |button| }}
+    {{# if (isRowActionBatchable button.actionDefinition) }}
+    {
+      name: "{{ simpleActionDefinitionName button.actionDefinition }}",
+      id: "{{ getXMIID button }}::asBulk",
+      {{# if button.icon }}
+      startIcon: "{{ button.icon.iconName }}",
+      {{/ if }}
+      variant: 'text',
+      hiddenBy: {{# if button.hiddenBy }}true{{ else }}false{{/ if }},
+      label: { 'translationKey': '{{ getTranslationKeyForVisualElement button }}', 'defaultValue': '{{ button.label }}' },
+      enabled: (data: {{# with (getReferenceClassType table) as |classType| }}{{ classDataName (getReferenceClassType table) '' }}{{# if classType.isMapped }}Stored{{/ if }}[]{{/ with }}, selectionModel: GridRowSelectionModel, selectedRows: {{# with (getReferenceClassType table) as |classType| }}{{ classDataName (getReferenceClassType table) '' }}{{# if classType.isMapped }}Stored{{/ if }}[]{{/ with }}, ownerData?: any, isFormUpdateable?: () => boolean, rowModesModel?: GridRowModesModel): boolean => selectionModel.ids.size > 0,
+      isBulk: true,
+      bulkFromRowAction: true,
+    },
+    {{/ if }}
+    {{/ each }}
+    {{/ unless }}
+    {{/ if }}
   ];
 
   const rowActions: TableRowAction<{{# with (getReferenceClassType table) as |classType| }}{{# if classType.isMapped }}{{ classDataName (getReferenceClassType table) 'Stored' }}{{ else }}{{ classDataName (getReferenceClassType table) '' }}{{/ if }}{{/ with }}, {{ classDataName (getReferenceClassType table) 'Stored' }}>[] = [
@@ -302,9 +325,7 @@ export function {{ componentName table }}(props: {{ componentName table }}Props)
         dataElementId={ '{{ createId table.dataElement }}' }
         crudOperationsDisplayed={ {{ table.crudOperationsDisplayed }} }
         transferOperationsDisplayed={ {{ table.transferOperationsDisplayed }} }
-        {{# unless (checkboxSelectionEnabled table) }}
-        checkboxSelection={ false }
-        {{/ unless }}
+        checkboxSelection={ isSelector ? true : {{ boolValue (checkboxSelectionForOwnPage table) }} }
         {{# each table.rowActionDefinitions as |actionDefinition| }}
         {{# if actionDefinition.isOpenPageAction }}
         onRowClick={ actions.{{ simpleActionDefinitionName actionDefinition }} }
@@ -354,9 +375,7 @@ export function {{ componentName table }}(props: {{ componentName table }}Props)
         validationError={validationError}
         actions={actions}
         allowSelectMultiple={allowSelectMultiple}
-        {{# unless (checkboxSelectionEnabled table) }}
-        checkboxSelection={ false }
-        {{/ unless }}
+        checkboxSelection={ isSelector ? true : {{ boolValue (checkboxSelectionForOwnPage table) }} }
         dataElementId={ '{{ createId table.dataElement }}' }
         crudOperationsDisplayed={ {{ table.crudOperationsDisplayed }} }
         transferOperationsDisplayed={ {{ table.transferOperationsDisplayed }} }

--- a/judo-ui-react/src/main/resources/actor/src/containers/components/tag/index.tsx.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/containers/components/tag/index.tsx.hbs
@@ -46,7 +46,7 @@ export function {{ componentName table }}(props: {{ componentName table }}Props)
     storeDiff,
     refreshCounter,
     annotations = [],
-    allowSelectMultiple,
+    allowSelectMultiple = {{ boolValue (multiSelectAllowedForOwnPage table) }},
   } = props;
 
   const { t } = useTranslation();

--- a/judo-ui-react/src/main/resources/actor/src/utilities/table.ts.hbs
+++ b/judo-ui-react/src/main/resources/actor/src/utilities/table.ts.hbs
@@ -58,6 +58,13 @@ export interface ToolBarActionProps<T> {
     rowModesModel?: GridRowModesModel,
   ) => boolean;
   isBulk: boolean;
+  /**
+   * Marks an implicit bulk toolbar entry derived from a batchable row action.
+   * When true and `isBulk` is also true, the runtime fans the per-row action out
+   * across `selectedRows.current` sequentially instead of passing the whole array
+   * to a BulkX function.
+   */
+  bulkFromRowAction?: boolean;
   confirmation?: string;
   confirmationCondition?: boolean;
 }

--- a/judo-ui-react/src/test/java/hu/blackbelt/judo/ui/generator/react/CheckboxSelectionTest.java
+++ b/judo-ui-react/src/test/java/hu/blackbelt/judo/ui/generator/react/CheckboxSelectionTest.java
@@ -1,0 +1,502 @@
+package hu.blackbelt.judo.ui.generator.react;
+
+/*-
+ * #%L
+ * JUDO UI React Frontend Generator
+ * %%
+ * Copyright (C) 2018 - 2023 BlackBelt Technology
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
+import hu.blackbelt.judo.meta.ui.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the three-mode behavior of {@code Table.checkboxSelection} and the
+ * bulk-button collapse in {@link UiWidgetHelper#tableButtonVisibilityConditions}.
+ *
+ * The truth table for own-page context is:
+ *
+ *   checkboxSelection | tableHasAnyBulkAction | checkboxSelectionForOwnPage |
+ *                     |                       | multiSelectAllowedForOwnPage|
+ *   ------------------+-----------------------+-----------------------------+
+ *   null  (ENABLED)   | false                 | true                        |
+ *   null  (ENABLED)   | true                  | true                        |
+ *   ENABLED           | false                 | true                        |
+ *   ENABLED           | true                  | true                        |
+ *   DISABLED          | false                 | false                       |
+ *   DISABLED          | true                  | false                       |
+ *   AUTO              | false                 | false                       |
+ *   AUTO              | true                  | true                        |
+ *
+ * Selector-mode behavior is template-level (a runtime {@code isSelector} branch in
+ * {@code containers/components/table/index.tsx.hbs}) and is not testable from Java;
+ * it is covered by the itest snapshots in {@code RelationTest}.
+ */
+public class CheckboxSelectionTest {
+
+    private static final UiFactory FACTORY = UiFactory.eINSTANCE;
+
+    private static Table emptyTable() {
+        Table t = FACTORY.createTable();
+        // Tables in real models always have a TableActionButtonGroup, but the helper
+        // must also be null-safe; we test both shapes explicitly.
+        return t;
+    }
+
+    private static Table tableWithEmptyButtonGroup() {
+        Table t = FACTORY.createTable();
+        t.setTableActionButtonGroup(FACTORY.createButtonGroup());
+        return t;
+    }
+
+    /**
+     * On {@link ActionDefinition} only {@code isBulk} is a stored EAttribute.
+     * {@code getIsBulkDeleteAction()}, {@code getIsBulkRemoveAction()}, and
+     * {@code getIsBulkCallOperationAction()} are derived from the EClass identity
+     * (e.g. {@code this instanceof BulkDeleteActionDefinition}). The factory takes
+     * care of the latter; Tatami sets the former during model build and we mirror it
+     * here in fixtures so {@link UiWidgetHelper#tableButtonVisibilityConditions}
+     * sees a realistic shape.
+     */
+    private static BulkDeleteActionDefinition newBulkDeleteAction() {
+        BulkDeleteActionDefinition ad = FACTORY.createBulkDeleteActionDefinition();
+        ad.setIsBulk(true);
+        return ad;
+    }
+
+    private static BulkRemoveActionDefinition newBulkRemoveAction() {
+        BulkRemoveActionDefinition ad = FACTORY.createBulkRemoveActionDefinition();
+        ad.setIsBulk(true);
+        return ad;
+    }
+
+    private static BulkCallOperationActionDefinition newBulkCallOperationAction() {
+        BulkCallOperationActionDefinition ad = FACTORY.createBulkCallOperationActionDefinition();
+        ad.setIsBulk(true);
+        return ad;
+    }
+
+    private static Table tableWithBulkDelete() {
+        Table t = tableWithEmptyButtonGroup();
+        Button b = FACTORY.createButton();
+        b.setActionDefinition(newBulkDeleteAction());
+        t.getTableActionButtonGroup().getButtons().add(b);
+        return t;
+    }
+
+    private static Table tableWithBulkRemove() {
+        Table t = tableWithEmptyButtonGroup();
+        Button b = FACTORY.createButton();
+        b.setActionDefinition(newBulkRemoveAction());
+        t.getTableActionButtonGroup().getButtons().add(b);
+        return t;
+    }
+
+    private static Table tableWithBulkCallOperation() {
+        Table t = tableWithEmptyButtonGroup();
+        Button b = FACTORY.createButton();
+        b.setActionDefinition(newBulkCallOperationAction());
+        t.getTableActionButtonGroup().getButtons().add(b);
+        return t;
+    }
+
+    private static Table tableWithNonBulkOnly() {
+        Table t = tableWithEmptyButtonGroup();
+        Button b = FACTORY.createButton();
+        // DeleteActionDefinition is intentionally non-bulk (isBulk left at default false).
+        b.setActionDefinition(FACTORY.createDeleteActionDefinition());
+        t.getTableActionButtonGroup().getButtons().add(b);
+        return t;
+    }
+
+    // ---- row-action button-group fixtures ----
+
+    /**
+     * Adds a row action button (with the given action definition) to the table's
+     * {@code rowActionButtonGroup}, creating the group if missing.
+     */
+    private static Table withRowAction(Table t, ActionDefinition ad) {
+        if (t.getRowActionButtonGroup() == null) {
+            t.setRowActionButtonGroup(FACTORY.createButtonGroup());
+        }
+        Button b = FACTORY.createButton();
+        b.setActionDefinition(ad);
+        t.getRowActionButtonGroup().getButtons().add(b);
+        return t;
+    }
+
+    private static Table tableWithEmptyRowActionGroup() {
+        Table t = tableWithEmptyButtonGroup();
+        t.setRowActionButtonGroup(FACTORY.createButtonGroup());
+        return t;
+    }
+
+    private static Table tableWithRowDelete() {
+        return withRowAction(tableWithEmptyButtonGroup(), FACTORY.createRowDeleteActionDefinition());
+    }
+
+    private static Table tableWithRowParameterless() {
+        return withRowAction(tableWithEmptyButtonGroup(), FACTORY.createParameterlessCallOperationActionDefinition());
+    }
+
+    private static Table tableWithRowInputForm() {
+        return withRowAction(tableWithEmptyButtonGroup(), FACTORY.createInputFormCallOperationActionDefinition());
+    }
+
+    private static Table tableWithRowInputSelector() {
+        return withRowAction(tableWithEmptyButtonGroup(), FACTORY.createInputSelectorCallOperationActionDefinition());
+    }
+
+    private static Table tableWithRowOpenPage() {
+        return withRowAction(tableWithEmptyButtonGroup(), FACTORY.createOpenPageActionDefinition());
+    }
+
+    // ---- tableHasAnyBulkAction ----
+
+    @Test
+    void tableHasAnyBulkAction_nullTable_false() {
+        assertFalse(UiTableHelper.tableHasAnyBulkAction(null));
+    }
+
+    @Test
+    void tableHasAnyBulkAction_nullButtonGroup_false() {
+        assertFalse(UiTableHelper.tableHasAnyBulkAction(emptyTable()));
+    }
+
+    @Test
+    void tableHasAnyBulkAction_emptyButtonGroup_false() {
+        assertFalse(UiTableHelper.tableHasAnyBulkAction(tableWithEmptyButtonGroup()));
+    }
+
+    @Test
+    void tableHasAnyBulkAction_nonBulkOnly_false() {
+        assertFalse(UiTableHelper.tableHasAnyBulkAction(tableWithNonBulkOnly()));
+    }
+
+    @Test
+    void tableHasAnyBulkAction_bulkDelete_true() {
+        assertTrue(UiTableHelper.tableHasAnyBulkAction(tableWithBulkDelete()));
+    }
+
+    @Test
+    void tableHasAnyBulkAction_bulkRemove_true() {
+        assertTrue(UiTableHelper.tableHasAnyBulkAction(tableWithBulkRemove()));
+    }
+
+    @Test
+    void tableHasAnyBulkAction_bulkCallOperation_true() {
+        assertTrue(UiTableHelper.tableHasAnyBulkAction(tableWithBulkCallOperation()));
+    }
+
+    // ---- checkboxSelectionForOwnPage ----
+
+    @Test
+    void checkboxSelectionForOwnPage_nullEnumNoBulk_true() {
+        Table t = tableWithEmptyButtonGroup();
+        assertTrue(UiTableHelper.checkboxSelectionForOwnPage(t));
+    }
+
+    @Test
+    void checkboxSelectionForOwnPage_nullEnumWithBulk_true() {
+        Table t = tableWithBulkDelete();
+        assertTrue(UiTableHelper.checkboxSelectionForOwnPage(t));
+    }
+
+    @Test
+    void checkboxSelectionForOwnPage_enabledNoBulk_true() {
+        Table t = tableWithEmptyButtonGroup();
+        t.setCheckboxSelection(CheckboxSelection.ENABLED);
+        assertTrue(UiTableHelper.checkboxSelectionForOwnPage(t));
+    }
+
+    @Test
+    void checkboxSelectionForOwnPage_enabledWithBulk_true() {
+        Table t = tableWithBulkDelete();
+        t.setCheckboxSelection(CheckboxSelection.ENABLED);
+        assertTrue(UiTableHelper.checkboxSelectionForOwnPage(t));
+    }
+
+    @Test
+    void checkboxSelectionForOwnPage_disabledNoBulk_false() {
+        Table t = tableWithEmptyButtonGroup();
+        t.setCheckboxSelection(CheckboxSelection.DISABLED);
+        assertFalse(UiTableHelper.checkboxSelectionForOwnPage(t));
+    }
+
+    @Test
+    void checkboxSelectionForOwnPage_disabledWithBulk_false() {
+        Table t = tableWithBulkDelete();
+        t.setCheckboxSelection(CheckboxSelection.DISABLED);
+        assertFalse(UiTableHelper.checkboxSelectionForOwnPage(t));
+    }
+
+    @Test
+    void checkboxSelectionForOwnPage_autoNoBulk_false() {
+        Table t = tableWithEmptyButtonGroup();
+        t.setCheckboxSelection(CheckboxSelection.AUTO);
+        assertFalse(UiTableHelper.checkboxSelectionForOwnPage(t));
+    }
+
+    @Test
+    void checkboxSelectionForOwnPage_autoWithBulkDelete_true() {
+        Table t = tableWithBulkDelete();
+        t.setCheckboxSelection(CheckboxSelection.AUTO);
+        assertTrue(UiTableHelper.checkboxSelectionForOwnPage(t));
+    }
+
+    @Test
+    void checkboxSelectionForOwnPage_autoWithBulkRemove_true() {
+        Table t = tableWithBulkRemove();
+        t.setCheckboxSelection(CheckboxSelection.AUTO);
+        assertTrue(UiTableHelper.checkboxSelectionForOwnPage(t));
+    }
+
+    @Test
+    void checkboxSelectionForOwnPage_autoWithBulkCallOperation_true() {
+        Table t = tableWithBulkCallOperation();
+        t.setCheckboxSelection(CheckboxSelection.AUTO);
+        assertTrue(UiTableHelper.checkboxSelectionForOwnPage(t));
+    }
+
+    @Test
+    void checkboxSelectionForOwnPage_autoNonBulkOnly_false() {
+        Table t = tableWithNonBulkOnly();
+        t.setCheckboxSelection(CheckboxSelection.AUTO);
+        assertFalse(UiTableHelper.checkboxSelectionForOwnPage(t));
+    }
+
+    // ---- multiSelectAllowedForOwnPage (mirrors checkboxSelectionForOwnPage today) ----
+
+    @Test
+    void multiSelectAllowedForOwnPage_mirrorsCheckboxSelectionForOwnPage_disabled() {
+        Table t = tableWithBulkDelete();
+        t.setCheckboxSelection(CheckboxSelection.DISABLED);
+        assertEquals(
+                UiTableHelper.checkboxSelectionForOwnPage(t),
+                UiTableHelper.multiSelectAllowedForOwnPage(t));
+        assertFalse(UiTableHelper.multiSelectAllowedForOwnPage(t));
+    }
+
+    @Test
+    void multiSelectAllowedForOwnPage_mirrorsCheckboxSelectionForOwnPage_auto() {
+        Table withBulk = tableWithBulkDelete();
+        withBulk.setCheckboxSelection(CheckboxSelection.AUTO);
+        assertTrue(UiTableHelper.multiSelectAllowedForOwnPage(withBulk));
+
+        Table withoutBulk = tableWithEmptyButtonGroup();
+        withoutBulk.setCheckboxSelection(CheckboxSelection.AUTO);
+        assertFalse(UiTableHelper.multiSelectAllowedForOwnPage(withoutBulk));
+    }
+
+    // ---- UiWidgetHelper.tableButtonVisibilityConditions collapse ----
+
+    @Test
+    void tableButtonVisibilityConditions_disabledTableCollapsesBulkButtonToFalse() {
+        Table table = tableWithBulkDelete();
+        table.setCheckboxSelection(CheckboxSelection.DISABLED);
+        Button bulkButton = table.getTableActionButtonGroup().getButtons().get(0);
+        PageContainer container = FACTORY.createPageContainer();
+
+        assertEquals("false",
+                UiWidgetHelper.tableButtonVisibilityConditions(bulkButton, table, container));
+    }
+
+    @Test
+    void tableButtonVisibilityConditions_enabledTableKeepsSelectionExpression() {
+        Table table = tableWithBulkDelete();
+        table.setCheckboxSelection(CheckboxSelection.ENABLED);
+        Button bulkButton = table.getTableActionButtonGroup().getButtons().get(0);
+        PageContainer container = FACTORY.createPageContainer();
+
+        String result = UiWidgetHelper.tableButtonVisibilityConditions(bulkButton, table, container);
+        // Pre-existing expression survives unchanged for the ENABLED case.
+        assertEquals("selectionModel.ids.size > 0", result);
+    }
+
+    // ---- isRowActionBatchable ----
+
+    @Test
+    void isRowActionBatchable_null_false() {
+        assertFalse(UiTableHelper.isRowActionBatchable(null));
+    }
+
+    @Test
+    void isRowActionBatchable_rowDelete_true() {
+        assertTrue(UiTableHelper.isRowActionBatchable(FACTORY.createRowDeleteActionDefinition()));
+    }
+
+    @Test
+    void isRowActionBatchable_parameterless_true() {
+        assertTrue(UiTableHelper.isRowActionBatchable(FACTORY.createParameterlessCallOperationActionDefinition()));
+    }
+
+    @Test
+    void isRowActionBatchable_inputForm_false() {
+        assertFalse(UiTableHelper.isRowActionBatchable(FACTORY.createInputFormCallOperationActionDefinition()));
+    }
+
+    @Test
+    void isRowActionBatchable_inputSelector_false() {
+        assertFalse(UiTableHelper.isRowActionBatchable(FACTORY.createInputSelectorCallOperationActionDefinition()));
+    }
+
+    @Test
+    void isRowActionBatchable_openPage_false() {
+        assertFalse(UiTableHelper.isRowActionBatchable(FACTORY.createOpenPageActionDefinition()));
+    }
+
+    // ---- tableHasAnyBatchableRowAction (STRICT variant) ----
+
+    @Test
+    void tableHasAnyBatchableRowAction_nullTable_false() {
+        assertFalse(UiTableHelper.tableHasAnyBatchableRowAction(null));
+    }
+
+    @Test
+    void tableHasAnyBatchableRowAction_nullRowGroup_false() {
+        assertFalse(UiTableHelper.tableHasAnyBatchableRowAction(emptyTable()));
+    }
+
+    @Test
+    void tableHasAnyBatchableRowAction_emptyRowGroup_false() {
+        assertFalse(UiTableHelper.tableHasAnyBatchableRowAction(tableWithEmptyRowActionGroup()));
+    }
+
+    @Test
+    void tableHasAnyBatchableRowAction_rowDeleteOnly_true() {
+        assertTrue(UiTableHelper.tableHasAnyBatchableRowAction(tableWithRowDelete()));
+    }
+
+    @Test
+    void tableHasAnyBatchableRowAction_parameterlessOnly_true() {
+        assertTrue(UiTableHelper.tableHasAnyBatchableRowAction(tableWithRowParameterless()));
+    }
+
+    @Test
+    void tableHasAnyBatchableRowAction_rowDeleteAndParameterless_true() {
+        Table t = tableWithRowDelete();
+        withRowAction(t, FACTORY.createParameterlessCallOperationActionDefinition());
+        assertTrue(UiTableHelper.tableHasAnyBatchableRowAction(t));
+    }
+
+    @Test
+    void tableHasAnyBatchableRowAction_rowDeletePlusInputForm_falseByVeto() {
+        Table t = tableWithRowDelete();
+        withRowAction(t, FACTORY.createInputFormCallOperationActionDefinition());
+        assertFalse(UiTableHelper.tableHasAnyBatchableRowAction(t));
+    }
+
+    @Test
+    void tableHasAnyBatchableRowAction_rowDeletePlusInputSelector_falseByVeto() {
+        Table t = tableWithRowDelete();
+        withRowAction(t, FACTORY.createInputSelectorCallOperationActionDefinition());
+        assertFalse(UiTableHelper.tableHasAnyBatchableRowAction(t));
+    }
+
+    @Test
+    void tableHasAnyBatchableRowAction_inputFormOnly_false() {
+        assertFalse(UiTableHelper.tableHasAnyBatchableRowAction(tableWithRowInputForm()));
+    }
+
+    @Test
+    void tableHasAnyBatchableRowAction_inputSelectorOnly_false() {
+        assertFalse(UiTableHelper.tableHasAnyBatchableRowAction(tableWithRowInputSelector()));
+    }
+
+    @Test
+    void tableHasAnyBatchableRowAction_openPageOnly_false() {
+        // Neutral category: no batchable action means false even though no veto fires.
+        assertFalse(UiTableHelper.tableHasAnyBatchableRowAction(tableWithRowOpenPage()));
+    }
+
+    @Test
+    void tableHasAnyBatchableRowAction_rowDeletePlusOpenPage_true() {
+        Table t = tableWithRowDelete();
+        withRowAction(t, FACTORY.createOpenPageActionDefinition());
+        // OpenPage is neutral: doesn't enable, doesn't veto.
+        assertTrue(UiTableHelper.tableHasAnyBatchableRowAction(t));
+    }
+
+    // ---- checkboxSelectionForOwnPage AUTO + row-action matrix ----
+
+    @Test
+    void checkboxSelectionForOwnPage_autoRowDeleteOnly_true() {
+        Table t = tableWithRowDelete();
+        t.setCheckboxSelection(CheckboxSelection.AUTO);
+        assertTrue(UiTableHelper.checkboxSelectionForOwnPage(t));
+    }
+
+    @Test
+    void checkboxSelectionForOwnPage_autoParameterlessOnly_true() {
+        Table t = tableWithRowParameterless();
+        t.setCheckboxSelection(CheckboxSelection.AUTO);
+        assertTrue(UiTableHelper.checkboxSelectionForOwnPage(t));
+    }
+
+    @Test
+    void checkboxSelectionForOwnPage_autoRowDeletePlusInputForm_falseByVeto() {
+        Table t = tableWithRowDelete();
+        withRowAction(t, FACTORY.createInputFormCallOperationActionDefinition());
+        t.setCheckboxSelection(CheckboxSelection.AUTO);
+        assertFalse(UiTableHelper.checkboxSelectionForOwnPage(t));
+    }
+
+    @Test
+    void checkboxSelectionForOwnPage_autoBulkAndInputFormRow_trueByBulk() {
+        // Explicit BulkX still wins regardless of row-action veto.
+        Table t = tableWithBulkDelete();
+        withRowAction(t, FACTORY.createInputFormCallOperationActionDefinition());
+        t.setCheckboxSelection(CheckboxSelection.AUTO);
+        assertTrue(UiTableHelper.checkboxSelectionForOwnPage(t));
+    }
+
+    @Test
+    void checkboxSelectionForOwnPage_autoOpenPageRowOnly_false() {
+        Table t = tableWithRowOpenPage();
+        t.setCheckboxSelection(CheckboxSelection.AUTO);
+        // No batchable, no bulk → false.
+        assertFalse(UiTableHelper.checkboxSelectionForOwnPage(t));
+    }
+
+    @Test
+    void multiSelectAllowedForOwnPage_autoRowDeleteOnly_true() {
+        Table t = tableWithRowDelete();
+        t.setCheckboxSelection(CheckboxSelection.AUTO);
+        assertTrue(UiTableHelper.multiSelectAllowedForOwnPage(t));
+    }
+
+    @Test
+    void tableButtonVisibilityConditions_autoWithoutBulkUnreachable() {
+        // AUTO without bulk action means no bulk button exists, so the branch is
+        // unreachable in practice. We still document the helper's null-safety on a
+        // hypothetical orphan bulk button attached to an AUTO-no-bulk table by
+        // exercising the collapse path.
+        Table table = tableWithEmptyButtonGroup();
+        table.setCheckboxSelection(CheckboxSelection.AUTO);
+        Button orphan = FACTORY.createButton();
+        orphan.setActionDefinition(newBulkDeleteAction());
+        // Not added to the button group, so tableHasAnyBulkAction(table) == false,
+        // therefore multiSelectAllowedForOwnPage(table) == false, therefore collapse.
+        PageContainer container = FACTORY.createPageContainer();
+
+        assertEquals("false",
+                UiWidgetHelper.tableButtonVisibilityConditions(orphan, table, container));
+    }
+}

--- a/openspec/changes/archive/2026-05-07-trinary-combo-required-submit-guard/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-07-trinary-combo-required-submit-guard/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/archive/2026-05-15-JNG-6399-honor-checkbox-selection-mode/design.md
+++ b/openspec/changes/archive/2026-05-15-JNG-6399-honor-checkbox-selection-mode/design.md
@@ -1,0 +1,201 @@
+# Design
+
+## Problem reframed
+
+`Table.checkboxSelection` is set in the designer (`esm.odesign` rows 21761 & 23626 expose all three values: `ENABLED`, `DISABLED`, `AUTO`). It survives the ESM → UI transformation untouched (`tabular.etl` lines 25–27 forwards `s.checkboxSelection` to `t.checkboxSelection` when defined). The React generator then reads it back via:
+
+```java
+// judo-ui-react/src/main/java/.../UiTableHelper.java:373
+public static boolean checkboxSelectionEnabled(Table table) {
+    return table.getCheckboxSelection() == null
+        || table.getCheckboxSelection() != CheckboxSelection.DISABLED;
+}
+```
+
+This treats `null`, `ENABLED`, and `AUTO` as the same thing, and is the only gate. `DISABLED` correctly suppresses the checkbox column via the existing template:
+
+```handlebars
+{{# unless (checkboxSelectionEnabled table) }}
+  checkboxSelection={ false }
+{{/ unless }}
+```
+
+But `allowSelectMultiple` and the bulk toolbar buttons are not gated by it, so `DISABLED` leaves an inconsistent UI: no checkboxes, but Shift-click still selects multiple rows and bulk buttons are still visible.
+
+## Two contexts that converge on the same Table
+
+A given `Table` model element is rendered in two distinct contexts at runtime:
+
+| Context | Where | How it's identified at render time |
+|---|---|---|
+| 1. Own page | Access-table page, view page, regular form embedding | `isSelector === false` (computed from props: `selectionDiff` is not an array) |
+| 2. Selector dialog | Add/Set selector page, operation-input selector | `isSelector === true` |
+
+Both contexts use the same generated `containers/components/<Path>/<TableComponent>/index.tsx` file. The difference is purely runtime: the same component receives different props.
+
+### Current source of truth for `allowSelectMultiple`
+
+- **Context 1** (own page): the table component default `allowSelectMultiple = true`, propagated through `containers/components/table/index.tsx.hbs` line 137. No per-table override.
+- **Context 2** (selector): `dialogs/index.tsx.hbs` line 476 passes `allowSelectMultiple={{ allowSelectMultipleForPage(page) }}` — derived from whether the parent page has an Add action wired into a container button group (i.e. the form-add-multiple-from-Galaxy scenario).
+
+`checkboxSelection` is set the same way in both contexts (a single template position in `containers/components/table/index.tsx.hbs`), and today only Context 1 honors `DISABLED`. Context 2 also calls the gate, which means today **a `DISABLED` source table loses its selector checkbox column too** — that's a bug we will fix.
+
+## Decisions
+
+### D1. Three distinct modes; AUTO is the inference path
+
+The three enum values have non-overlapping meanings:
+
+| Value | Own-page rule |
+|---|---|
+| `ENABLED` (and ecore-default `null`) | Always show checkbox column, always allow multi-select |
+| `DISABLED` | Never show, never allow |
+| `AUTO` | Show iff `tableHasAnyBulkAction(table)` is true |
+
+A "bulk action" is any button on `tableActionButtonGroup` whose action definition is one of `BulkDeleteActionDefinition`, `BulkRemoveActionDefinition`, or `BulkCallOperationActionDefinition`. The list is closed (no custom-action escape hatch) so the helper is deterministic.
+
+Reasoning: ENABLED is the literal "yes" path — no inference. AUTO is opt-in smart behavior the modeler invokes deliberately by picking it in the designer. DISABLED is the literal "no" path. Each value answers exactly one question, with no overlap.
+
+### D2. Selector context overrides everything
+
+When the table renders in selector mode (`isSelector === true`), the source table's `checkboxSelection` is ignored entirely, regardless of value. The checkbox column always renders and `allowSelectMultiple` is derived from `allowSelectMultipleForPage(page)`. This applies to all three modes (ENABLED, DISABLED, AUTO).
+
+The override happens at template time, not in the Java helper, because the helper has no notion of "which page is hosting this Table right now".
+
+Implementation:
+
+- For `checkboxSelection` (a JSX prop deep inside the component body), the template emits a literal runtime ternary `checkboxSelection={ isSelector ? true : <own-page literal> }` because `isSelector` is in scope at that point.
+- For `allowSelectMultiple` (a destructured prop default at the top of the component, *above* the `useMemo` that binds `isSelector`), the template emits only the own-page literal: `allowSelectMultiple = <own-page literal>,`. The destructure default cannot reference `isSelector` without a TDZ violation. This is safe because the only caller that puts the table in selector mode (`dialogs/index.tsx.hbs:476`) **always** passes the prop explicitly via `allowSelectMultiple={ allowSelectMultipleForPage(page) }`, so the destructure default only fires in own-page context, which is exactly the value we wrote. Own-page callers (`containers/widget-fragments/table.hbs:47`) only forward the prop under `{{# if container.table }}` (selector-only branch); the own-page branch omits the prop and the default fires.
+
+The Java helpers compute only the own-page side; selector-mode rendering is fully handled at the call site.
+
+### D3. Bulk toolbar buttons under DISABLED and AUTO
+
+Bulk toolbar buttons (`isBulk: true` in `toolBarActions`) are only emitted in own-page context (their `actionDefinition` lives in the source `TransferObjectTableTableButtonGroup`; selectors don't render that group's bulk subset because selector pages don't pull in `tableActionButtonGroup` the same way). `UiWidgetHelper.tableButtonVisibilityConditions` for `isBulk` actions today returns `"selectionModel.ids.size > 0"`.
+
+We extend it to additionally evaluate `multiSelectAllowedForOwnPage(table)` at generate time:
+
+- `DISABLED` → helper returns `false` → `enabled:` callback collapses to `false` → button hidden.
+- `AUTO` with no bulk actions → by definition there are no bulk buttons to hide. (The AUTO inference predicate is exactly `tableHasAnyBulkAction`, so this branch is unreachable.)
+- `AUTO` with bulk actions → helper returns `true` → buttons render normally.
+- `ENABLED` → buttons render normally regardless of whether they exist.
+
+The selector context is unaffected because selector dialogs don't display bulk buttons in their toolbar — they show the page-level Add/Back/Set buttons defined in `TransferObjectTableButtonGroup`, which is a different list.
+
+### D4. Card and Tag representations honor DISABLED too
+
+`representationComponent = CARD` and `representationComponent = TAG` render via separate component templates (`containers/components/cards/index.tsx.hbs`, `containers/components/tag/index.tsx.hbs`). Both accept `allowSelectMultiple`. The same gate applies: own-page context honors DISABLED, selector context overrides.
+
+For CARD/TAG there is no "checkbox column" concept per se; the toggle is purely about whether row click contributes to a selection set. The Java helper treats them uniformly with `Table`.
+
+## New / changed Java helpers
+
+```java
+// UiTableHelper.java
+
+/**
+ * True iff the table has at least one table-level bulk action button.
+ * The closed list of bulk action definitions:
+ *   - BulkDeleteActionDefinition
+ *   - BulkRemoveActionDefinition
+ *   - BulkCallOperationActionDefinition
+ */
+public static boolean tableHasAnyBulkAction(Table table) {
+    if (table.getTableActionButtonGroup() == null) {
+        return false;
+    }
+    return table.getTableActionButtonGroup().getButtons().stream()
+        .map(Button::getActionDefinition)
+        .anyMatch(ad -> ad.getIsBulkDeleteAction()
+                     || ad.getIsBulkRemoveAction()
+                     || ad.getIsBulkCallOperationAction());
+}
+
+/**
+ * True iff the checkbox column should render when this table is on its own page.
+ *   ENABLED / null  → true
+ *   DISABLED        → false
+ *   AUTO            → tableHasAnyBulkAction(table)
+ */
+public static boolean checkboxSelectionForOwnPage(Table table) {
+    CheckboxSelection cb = table.getCheckboxSelection();
+    if (cb == CheckboxSelection.DISABLED) return false;
+    if (cb == CheckboxSelection.AUTO)     return tableHasAnyBulkAction(table);
+    return true; // ENABLED or null
+}
+
+/**
+ * True iff multi-row select should be allowed when this table is on its own page.
+ * Mirrors checkboxSelectionForOwnPage exactly.
+ */
+public static boolean multiSelectAllowedForOwnPage(Table table) {
+    return checkboxSelectionForOwnPage(table);
+}
+
+// The old checkboxSelectionEnabled(table) helper is replaced by the above.
+// Its sole template caller is migrated to a runtime expression
+// (see template change below) so the rename is safe.
+```
+
+The two output helpers are kept as separate methods (rather than one with two callers) so future divergence — e.g. "AUTO shows the column but disallows multi-select" — can land without renaming.
+
+## Template changes
+
+### `containers/components/table/index.tsx.hbs`
+
+**Before** (two occurrences, one per Eager / Lazy branch):
+
+```handlebars
+{{# unless (checkboxSelectionEnabled table) }}
+  checkboxSelection={ false }
+{{/ unless }}
+```
+
+**After**:
+
+```handlebars
+checkboxSelection={ isSelector ? true : {{ boolValue (checkboxSelectionForOwnPage table) }} }
+```
+
+(MUI's `<DataGrid checkboxSelection>` defaults to `false`, so passing the boolean explicitly is correct.)
+
+`allowSelectMultiple` default at line 137 changes from:
+
+```ts
+allowSelectMultiple = true,
+```
+
+to:
+
+```ts
+allowSelectMultiple = {{ boolValue (multiSelectAllowedForOwnPage table) }},
+```
+
+Note on the missing `isSelector` ternary: `allowSelectMultiple` is explicitly passed by `dialogs/index.tsx.hbs:476` (from `allowSelectMultipleForPage(page)`) when the page is a selector, and the destructured default fires only when the prop is undefined. Selector callers always pass it; own-page callers (`containers/widget-fragments/table.hbs:47`, gated by `{{# if container.table }}`) only pass it in selector branches. So the destructure default fires exclusively in own-page context, which is the literal we wrote. The author's first instinct to write `isSelector ? true : <literal>` here would have been a temporal-dead-zone error — `isSelector` is declared by a `useMemo` *below* the destructure block.
+
+### `containers/components/cards/index.tsx.hbs` and `containers/components/tag/index.tsx.hbs`
+
+Same `allowSelectMultiple` default shift.
+
+### `UiWidgetHelper.tableButtonVisibilityConditions`
+
+For any button whose `actionDefinition.isIsBulk()` is true, prepend `multiSelectAllowedForOwnPage(table)` (compile-time literal `true` / `false`) ANDed into the result. When `false`, the entire JS condition collapses to `false` and the toolbar entry is rendered with `enabled: () => false`. Combined with no checkbox column → no selection → bulk button greys out and is functionally unreachable, matching user expectation.
+
+## Test fixture
+
+`judo-ui-react-itest/RelationTest/model/RelationTest-ui.model` will gain `checkboxSelection="DISABLED"` on exactly one Table chosen to be:
+
+1. Reachable from at least one actor's generated app
+2. Not also used as a selector elsewhere (to keep the test isolated)
+3. Not a Card / Tag representation (separate test for those if we want one)
+
+After regeneration, the affected component's `index.tsx` will pass `checkboxSelection={false}` and `allowSelectMultiple={false}` in own-page context. The corresponding actor's snapshot file is updated in the same commit.
+
+If we additionally want to lock in the selector override, a second fixture is added: a *different* table marked DISABLED that is ALSO opened as a selector from another page. The generated selector dialog must still pass `checkboxSelection={true}` and `allowSelectMultiple={allowSelectMultipleForPage}`. This is the regression guard against future "helpful" simplifications that forget the selector override.
+
+## Risk inventory
+
+- **Snapshot churn**: zero on existing models (no current itest UI model sets `checkboxSelection=`). The added fixtures are the only intentional diff.
+- **Backward compatibility for downstream consumers**: customers whose models do not touch `checkboxSelection` see no change. Customers who explicitly set `DISABLED` and previously worked around the inconsistency by post-processing the generated app: their workaround becomes unnecessary; output now matches their intent.
+- **AUTO inference correctness**: any model that previously set `AUTO` (none in current itests) will now render its checkbox column conditionally on bulk-action presence instead of unconditionally. This is intentional. Customers who wanted unconditional checkboxes must pick `ENABLED` explicitly.
+- **"No bulk → no checkbox" only fires under AUTO**: a customer who picks `ENABLED` on a bulk-less table gets a usable but pointless checkbox column. This is by design — the modeler's pick is law.

--- a/openspec/changes/archive/2026-05-15-JNG-6399-honor-checkbox-selection-mode/proposal.md
+++ b/openspec/changes/archive/2026-05-15-JNG-6399-honor-checkbox-selection-mode/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+The UI metamodel exposes `Table.checkboxSelection` with three literals (`ENABLED`, `DISABLED`, `AUTO`) and the designer surfaces all three as a user-facing pick. Today the React generator does not honor that pick faithfully:
+
+- `UiTableHelper.checkboxSelectionEnabled(table)` returns `true` for both `ENABLED` and `AUTO`, conflating them.
+- `DISABLED` hides the checkbox column but does **not** disable row multi-select, leaving the underlying MUI DataGrid in an inconsistent state (no checkboxes, yet Shift-click multi-row selection still works and bulk toolbar buttons remain visible).
+- The modeler's explicit pick in the designer is therefore partially ignored.
+
+The fix is small and entirely template-side: respect what the modeler typed.
+
+## What Changes
+
+### Display-page tables (the table is rendered on its own page/view)
+
+The three enum values gain distinct, non-overlapping meanings:
+
+- `ENABLED` (and the ecore default `null`) — always render the checkbox column, always allow multi-select. No inference, no exceptions. Current behavior preserved for any model that doesn't touch the field.
+- `DISABLED` — never render the checkbox column, disable row multi-select, hide bulk toolbar buttons. Modeler's explicit opt-out.
+- `AUTO` — let the generator decide based on the table's model. The checkbox column renders if and only if the table has at least one bulk action (`BulkDelete`, `BulkRemove`, or `BulkCallOperation`). When no bulk action exists, the checkbox column and multi-select are suppressed. This is the "smart" mode the original ticket wording asked for, now scoped to opt-in via `AUTO`.
+
+The ecore default `ENABLED` is preserved — no metamodel change. AUTO is opt-in: a modeler must explicitly pick it in the designer.
+
+### Selector-mode tables (the same Table opened as an Add/Set selector or Operation Input selector)
+
+- Selectors SHALL continue to render the checkbox column and honor the existing page-level `allowSelectMultipleForPage` logic, independent of the source table's `checkboxSelection` value.
+- Rationale: the user observation about "form-add-multiple from Galaxy" — when a form opens a selector dialog to pick rows, multi-select is part of the selector contract, not the source table's display preference. A modeler's `DISABLED` on the data display does not invalidate the picker.
+
+### Non-goals
+
+- The original ticket's blanket rule "Table with no bulk operation → no checkbox column" is NOT applied to every table. It applies only when the modeler picks `AUTO`. If the modeler picks `ENABLED` (or never touched the field), the checkbox column appears even on tables with zero bulk operations. The modeler's pick is law.
+- The access-table / mapped-transfer-selector decoupling caveat is split off into a separate follow-up ticket. The change set here does not touch any selector-page-generation rule and therefore cannot regress selector behavior.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `data-tables`: The "Row Selection" requirement is rewritten so the three enum values have distinct meanings — `ENABLED` always shows, `DISABLED` always hides, `AUTO` infers from bulk-action presence — and selector-mode behavior is exempted from the source table's setting in all three modes.
+
+## Impact
+
+- **Java helpers modified**: `UiTableHelper.java` (existing `checkboxSelectionEnabled` replaced by mode-aware helpers, plus a new `tableHasAnyBulkAction` for AUTO inference), `UiWidgetHelper.tableButtonVisibilityConditions` (one extra AND for isBulk branches under DISABLED).
+- **Templates modified**: `containers/components/table/index.tsx.hbs` (runtime-gated checkbox + allowSelectMultiple), `containers/components/cards/index.tsx.hbs` and `containers/components/tag/index.tsx.hbs` (same gate, own-page context only).
+- **Test fixture added**: one Table in `RelationTest` model gains `checkboxSelection="DISABLED"` so the change is observable in snapshots.
+- **Itest snapshots**: zero diff for tables that don't set the attribute (today: all 6 itest UI models have zero occurrences of `checkboxSelection=`). Diff only on the new fixture and on any actor where the new fixture is reachable.
+- **No metamodel changes** in `judo-meta-ui` or `judo-meta-esm`.
+- **No transformation changes** in `judo-tatami-client` or `judo-tatami-jsl`.
+- **No breaking changes** for models that do not set `checkboxSelection` or set it to `ENABLED` / `AUTO`.
+
+## Out of Scope (separate tickets)
+
+- **Selector ↔ access decoupling**: when an access entry is removed in the modeler, mapped transfer selectors disappear from the selector list. This is a `judo-tatami-jsl` / `judo-tatami-client/esm2ui` rule wiring issue (selector page is `@lazy`-generated from the access entry, not from the selector source). To be filed as a separate JIRA ticket against the appropriate tatami repo.
+- **JSL keyword for `checkbox: enabled|disabled|auto`**: the JSL DSL has no first-class syntax for the field today. Modelers using JSL inherit the ecore default. Out of scope here.

--- a/openspec/changes/archive/2026-05-15-JNG-6399-honor-checkbox-selection-mode/specs/data-tables/spec.md
+++ b/openspec/changes/archive/2026-05-15-JNG-6399-honor-checkbox-selection-mode/specs/data-tables/spec.md
@@ -1,0 +1,72 @@
+## MODIFIED Requirements
+
+### Requirement: Row Selection
+
+The generator SHALL honor `Table.checkboxSelection` faithfully when the table renders on its own page (own-page context), and SHALL exempt selector-mode rendering from that value.
+
+**Own-page context** is any rendering where the table is the page's primary content (access table page, view page, table embedded in a regular form). It is identified at runtime by `isSelector === false`.
+
+**Selector-mode context** is any rendering where the table is opened as an Add / Set / Operation-Input selector dialog. It is identified at runtime by `isSelector === true`.
+
+#### Own-page context rules
+
+The three enum values have distinct, non-overlapping meanings:
+
+`checkboxSelection = ENABLED` (and the ecore-default `null`) SHALL render the checkbox column and default `allowSelectMultiple` to `true`. No inference, no exceptions — the column appears even on tables with zero bulk operations. Bulk toolbar buttons SHALL appear when present in the model.
+
+`checkboxSelection = DISABLED` SHALL:
+
+- Hide the checkbox column on the generated MUI DataGrid.
+- Set the default `allowSelectMultiple` prop to `false` so Shift-click / Ctrl-click do not produce multi-row selections.
+- Hide any bulk toolbar buttons (`isBulk: true` toolbar entries) so the toolbar reflects that bulk actions are unreachable in this layout.
+
+`checkboxSelection = AUTO` SHALL render the checkbox column and allow multi-select if and only if the table has at least one bulk action. A "bulk action" is a button on `tableActionButtonGroup` whose action definition is one of `BulkDeleteActionDefinition`, `BulkRemoveActionDefinition`, or `BulkCallOperationActionDefinition`. The list is closed. When no such button exists, AUTO behaves identically to `DISABLED` (no column, no multi-select). When at least one exists, AUTO behaves identically to `ENABLED`.
+
+#### Selector-mode context rules
+
+Selector-mode rendering SHALL ignore the source table's `checkboxSelection` value. The checkbox column SHALL always render, and `allowSelectMultiple` SHALL be derived from the page-level `allowSelectMultipleForPage` helper (which inspects whether the parent page has an Add action wired into a container button group).
+
+Rationale: a selector dialog's purpose is to pick rows. The modeler's `DISABLED` describes the data display preference, not the picker contract. Form scenarios such as "open Galaxy as a selector to add multiple to a form" remain unaffected.
+
+#### Card and Tag representations
+
+For `representationComponent = CARD` and `representationComponent = TAG`, the `allowSelectMultiple` rules above apply identically (DISABLED ⇒ no multi, ENABLED/AUTO ⇒ multi). There is no checkbox column to hide in these representations; the gate is purely about whether row click contributes to the selection set.
+
+#### Scenario: DISABLED on a table's own page
+
+- **GIVEN** a `Table` with `checkboxSelection = DISABLED`
+- **AND** the table is rendered on a page where `isSelector = false`
+- **WHEN** the React app loads that page
+- **THEN** the generated DataGrid has `checkboxSelection={false}`
+- **AND** `allowSelectMultiple` resolves to `false`
+- **AND** any bulk toolbar buttons render with `enabled: () => false` (i.e. are hidden by `tableButtonVisibilityConditions`)
+
+#### Scenario: DISABLED on a table used as a selector
+
+- **GIVEN** the same `Table` with `checkboxSelection = DISABLED`
+- **AND** an Add action elsewhere opens this table as a selector dialog
+- **WHEN** the user opens that selector dialog
+- **THEN** the embedded DataGrid renders the checkbox column
+- **AND** `allowSelectMultiple` is derived from `allowSelectMultipleForPage(page)` — typically `true` when the parent Add action is wired through
+
+#### Scenario: ENABLED is the default and produces the previous behavior
+
+- **GIVEN** a `Table` whose `checkboxSelection` attribute is not set in the model (EMF ecore default `ENABLED`)
+- **THEN** the generated component behaves exactly as in versions prior to this change: checkbox column visible, multi-select on, bulk buttons visible
+
+#### Scenario: AUTO with at least one bulk action
+
+- **GIVEN** a `Table` with `checkboxSelection = AUTO`
+- **AND** the table's `tableActionButtonGroup` contains at least one BulkDelete, BulkRemove, or BulkCallOperation button
+- **THEN** the generated component behaves identically to `checkboxSelection = ENABLED` (column visible, multi-select on, bulk buttons rendered)
+
+#### Scenario: AUTO without any bulk action
+
+- **GIVEN** a `Table` with `checkboxSelection = AUTO`
+- **AND** the table's `tableActionButtonGroup` contains no BulkDelete, BulkRemove, or BulkCallOperation button
+- **THEN** the generated component behaves identically to `checkboxSelection = DISABLED` (column hidden, multi-select off)
+- **AND** the selector-mode override still applies: opening this table as a selector still renders the checkbox column
+
+**Key Helpers**: `UiTableHelper.tableHasAnyBulkAction()`, `UiTableHelper.checkboxSelectionForOwnPage()`, `UiTableHelper.multiSelectAllowedForOwnPage()`, `UiPageHelper.allowSelectMultipleForPage()`, `UiWidgetHelper.tableButtonVisibilityConditions()`
+
+**Template positions**: `containers/components/table/index.tsx.hbs` (the `checkboxSelection={...}` inline expression and the `allowSelectMultiple` destructured default), `containers/components/cards/index.tsx.hbs`, `containers/components/tag/index.tsx.hbs`

--- a/openspec/changes/archive/2026-05-15-JNG-6399-honor-checkbox-selection-mode/tasks.md
+++ b/openspec/changes/archive/2026-05-15-JNG-6399-honor-checkbox-selection-mode/tasks.md
@@ -1,0 +1,77 @@
+## 1. Java helpers (`UiTableHelper.java`)
+
+- [x] 1.1 Add `tableHasAnyBulkAction(Table table)` that returns `true` iff `table.tableActionButtonGroup` contains at least one button whose action definition is `BulkDeleteActionDefinition`, `BulkRemoveActionDefinition`, or `BulkCallOperationActionDefinition`. Null-safe on the button group.
+- [x] 1.2 Add `checkboxSelectionForOwnPage(Table table)` implementing the three-mode logic: `DISABLED → false`, `AUTO → tableHasAnyBulkAction(table)`, anything else (`ENABLED` / `null`) `→ true`.
+- [x] 1.3 Add `multiSelectAllowedForOwnPage(Table table)` returning the same value as `checkboxSelectionForOwnPage`. Kept as a separate method so a future divergence (e.g. "AUTO shows column but disallows multi") doesn't require renaming.
+- [x] 1.4 Remove `checkboxSelectionEnabled(Table table)` once all template callers are migrated (task 2).
+
+## 2. Template wiring (`containers/components/table/index.tsx.hbs`)
+
+- [x] 2.1 Replace the two existing `{{# unless (checkboxSelectionEnabled table) }} checkboxSelection={ false } {{/ unless }}` blocks (one in the Eager branch, one in the Lazy branch) with a single inline expression: `checkboxSelection={ isSelector ? true : {{ boolValue (checkboxSelectionForOwnPage table) }} }`.
+- [x] 2.2 Change the destructured default at the top of the component from `allowSelectMultiple = true,` to `allowSelectMultiple = {{ boolValue (multiSelectAllowedForOwnPage table) }},` (Option 3 deviation: plain literal, no `isSelector ? true : ...` ternary — `isSelector` is bound via `useMemo` *after* the destructure so referencing it there would TDZ. Selector callers always pass the prop explicitly via `dialogs/index.tsx.hbs:476`, so the default only fires in own-page context.)
+
+## 3. Template wiring — Card and Tag representations
+
+- [x] 3.1 `containers/components/cards/index.tsx.hbs`: same `allowSelectMultiple` default shift as task 2.2.
+- [x] 3.2 `containers/components/tag/index.tsx.hbs`: same shift.
+
+## 4. Bulk-button hiding (`UiWidgetHelper.tableButtonVisibilityConditions`)
+
+- [x] 4.1 For any `button.getActionDefinition().isIsBulk()` branch, prepend the generate-time literal of `multiSelectAllowedForOwnPage(table)` ANDed into the returned condition string. When the modeler picked DISABLED, the generated `enabled:` callback evaluates to `false` and the toolbar entry stays hidden. (Implemented as a single early-return short-circuit at the top of the method: if bulk AND `multiSelectAllowedForOwnPage(table) == false`, return the literal `"false"`, which collapses all three downstream `isBulk` branches uniformly.)
+
+## 5. Test fixture for own-page DISABLED
+
+- [x] 5.1 In `judo-ui-react-itest/RelationTest/model/RelationTest-ui.model`, add `checkboxSelection="DISABLED"` to one Table that:
+      - is rendered on its own page
+      - is **not** opened as a selector by any other page — **DEVIATION**: every top-level access table in `RelationTest-ui.model` (`TransferObjectTableTable`) is also wired as an Add/Set selector source. There is no candidate that is own-page-only. Picked `InlineEditTransfer_Table` (line 1527, xmi:id `_VXrnUISbEe-FwPSSWSnNlQ`), which serves as own-page **and** selector context. This actually folds task §6 into the same fixture: one model edit exercises both contexts on the same Table, and the snapshot evidence confirms the selector override.
+      - is a TABLE representation (not Card/Tag) — yes, `representationComponent` unset = TABLE
+- [x] 5.2 Regenerate the affected actor's snapshots and commit only the expected diff:
+      - `checkboxSelection={isSelector ? true : false}` in the generated component — confirmed in `InlineEditTransfer_TableComponent/index.tsx:431`
+      - `allowSelectMultiple = false,` in destructure — confirmed in `index.tsx:109`
+      - bulk toolbar entries drop to `enabled: () => false` — confirmed for both `bulkRemoveAction` (line 327–335) and `bulkDeleteAction` (line 344+); see commit
+- [x] 5.3 Verify nothing else in the snapshot diffs — confirmed: full `mvn clean install` of the RelationTest actor passes, the only snapshot-checker diff was the tag-template `allowSelectMultiple = true,` line (task §3.2), now committed to snapshot.
+
+## 5b. Test fixture for own-page AUTO
+
+- [x] 5b.1 In the same model, add `checkboxSelection="AUTO"` to two Tables:
+      - one **with** at least one bulk action button (BulkDelete / BulkRemove / BulkCallOperation) — picked `TransferObject A Table` (line 2959, xmi:id `_WfaFoM7uEe27c5LD4UmIwA`).
+      - one **without** any bulk action button — **DEVIATION**: every Table in `RelationTest-ui.model` (33 Tables total: 10 access-level + 11 non-TAG relation tables + 12 TAG tables) has at least one bulk action. There is no candidate for AUTO-without-bulk in this fixture model. The AUTO-without-bulk truth table value is fully covered by unit tests in `CheckboxSelectionTest` (`checkboxSelectionForOwnPage_autoNoBulk_false`, `checkboxSelectionForOwnPage_autoNonBulkOnly_false`, `multiSelectAllowedForOwnPage_mirrorsCheckboxSelectionForOwnPage_auto`). Marking this sub-task as covered by unit test only.
+- [x] 5b.2 Regenerate and verify:
+      - the AUTO-with-bulk table behaves identically to ENABLED — confirmed: `TransferObjectA TransferObject_TableComponent/index.tsx:109` emits `allowSelectMultiple = true,` and line 428 emits `checkboxSelection={isSelector ? true : true}`, identical to the ENABLED-default `TransferObjectB` and friends.
+      - the AUTO-without-bulk table behaves identically to DISABLED — covered by unit test only, see 5b.1 deviation.
+- [x] 5b.3 Verify nothing else in the snapshot diffs — confirmed by the same `mvn clean install` run; `TransferObject A` has no curated snapshot file (it isn't in the 3-file curated set), so AUTO+bulk is verified by direct file inspection of the generated component, not by snapshot diff.
+
+## 6. Regression fixture for selector override
+
+- [x] 6.1 In the same `RelationTest-ui.model`, find a Table that is opened as a selector from some Add/Set action AND mark it `checkboxSelection="DISABLED"` — folded into task §5.1: `InlineEditTransfer_Table` is itself the selector source (it has both `TransferObjectTableAddSelectorOpenPageActionDefinition` and `TransferObjectTableSetSelectorOpenPageActionDefinition`; see model lines 1553, 1557), so the DISABLED edit there covers both contexts simultaneously — no second fixture edit needed.
+- [x] 6.2 Confirm the regenerated *selector dialog* output keeps `checkboxSelection={true}` and `allowSelectMultiple={true}` (via `allowSelectMultipleForPage`) — confirmed: the same `index.tsx:431` emits `checkboxSelection={isSelector ? true : false}`, so at runtime when the page is a selector (`isSelector === true`), the prop resolves to `true`. The `allowSelectMultiple` prop is passed explicitly by `dialogs/index.tsx:476` from `allowSelectMultipleForPage(page)`, bypassing the destructure default.
+- [x] 6.3 Confirm the same Table's *own-page* rendering shows `false` for both — confirmed (see 5.2): destructure default `false`, JSX ternary `isSelector ? true : false` → `false` in own-page.
+- [x] 6.4 Repeat for `checkboxSelection="AUTO"` on a Table with no bulk action: own-page → column hidden, selector → column visible. Confirms AUTO's selector override matches DISABLED's selector override. **DEVIATION**: same as 5b.1 — no bulk-less Table exists in `RelationTest-ui.model`; the AUTO-no-bulk × selector-override matrix cell is logically equivalent to DISABLED × selector-override (both helpers return false; selector template branch overrides identically). Covered by 6.1–6.3 (DISABLED) + the AUTO→DISABLED equivalence proven by unit tests.
+
+## 7. Unit tests (Java side)
+
+- [x] 7.1 Add tests in the React generator's unit test suite for `UiTableHelper` (see `judo-ui-react/src/test/java/.../CheckboxSelectionTest.java`):
+      - `tableHasAnyBulkAction`: returns true when the table button group contains BulkDelete / BulkRemove / BulkCallOperation; false otherwise; null-safe.
+      - `checkboxSelectionForOwnPage`:
+          - `ENABLED` → true (regardless of bulk presence)
+          - `null`    → true (regardless of bulk presence)
+          - `DISABLED` → false (regardless of bulk presence)
+          - `AUTO` with bulk action → true
+          - `AUTO` without bulk action → false
+      - `multiSelectAllowedForOwnPage`: same matrix.
+- [x] 7.2 Add test that `UiWidgetHelper.tableButtonVisibilityConditions` collapses to `false` for an `isBulk` button when its containing Table has `checkboxSelection = DISABLED`.
+
+## 8. Spec capture
+
+- [x] 8.1 Spec delta written under `openspec/changes/JNG-6399-honor-checkbox-selection-mode/specs/data-tables/spec.md` — modifies the existing "Row Selection" requirement in the `data-tables` capability. Already drafted in this change set.
+
+## 9. Build verification
+
+- [x] 9.1 `mvn clean install -pl judo-ui-react -am` passes — 27/27 unit tests green, generator bundle installed.
+- [x] 9.2 Full itest build green: `mvn clean install -pl judo-ui-react-itest/RelationTest/relation_test__actor -DskipPrepareNodeJS` — **BUILD SUCCESS** including generator phase, snapshot-checker phase, and Vite production build phase. Other itests (`ActionGroupTest`, `CRUDActionsTest`, etc.) not run in this session; expected zero diff because none of them set `checkboxSelection=` in their UI models (re-verify before merge).
+- [x] 9.3 Diff-checker plugin reports zero unexpected diffs (only those covered by tasks 5–6 are present) — the only diff during the run was the task §3.2 tag-template `allowSelectMultiple = true,` shift on `TagContainerTransfer_View_Edit/.../ManyAggregationCompostionComponent/index.tsx`. This is **task §3.2's intended diff** (every TAG-representation table receives the destructure default change). Snapshot committed.
+
+## 10. Follow-up tickets (out of this change set)
+
+- [] 10.1 File a separate JIRA ticket against `judo-tatami-jsl` (and mirrored against `judo-tatami-client/esm2ui`) for the access ↔ selector decoupling — selector page generation today fires from access entries (`menuTableDeclarationAddSelectorPage.etl`, `viewTableDeclarationAddSelectorPage.etl`); removing the access entry deletes the selector page. Documented in the proposal's "Out of Scope" section.
+- [ ] 10.2 Optional: file a ticket against `judo-meta-jsl` for a JSL DSL keyword exposing `checkboxSelection`, so JSL modelers can pick the value without falling back to the ecore default.

--- a/openspec/changes/jng-6399-followup-auto-from-batchable-row-actions/.openspec.yaml
+++ b/openspec/changes/jng-6399-followup-auto-from-batchable-row-actions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-12

--- a/openspec/changes/jng-6399-followup-auto-from-batchable-row-actions/design.md
+++ b/openspec/changes/jng-6399-followup-auto-from-batchable-row-actions/design.md
@@ -1,0 +1,143 @@
+# Design
+
+## Problem reframed
+
+JNG-6399 shipped `AUTO = tableHasAnyBulkAction(table)` — a single predicate that checks the toolbar's `tableActionButtonGroup` for BulkX buttons. This misses a common case: tables whose only actionable surface is per-row, but where those row actions are semantically batchable (no per-row input needed).
+
+The modeler picks AUTO expecting "smart" behavior, but gets `false` on a table with `RowDelete` row actions and no BulkX. The modeler then has to either (a) add an explicit `BulkDelete` button (duplicating intent) or (b) switch to `ENABLED` (losing the smart inference).
+
+## Decision 1: STRICT veto on input-needing row actions
+
+The AUTO predicate considers row actions from `rowActionButtonGroup`. Row actions fall into three categories:
+
+| Category | Closed list | Rationale |
+|---|---|---|
+| **Batchable** | `RowDeleteActionDefinition`, `ParameterlessCallOperationActionDefinition` | No per-row input needed; semantically N-row-safe. |
+| **Input-needing (veto)** | `InputFormCallOperationActionDefinition`, `InputSelectorCallOperationActionDefinition` | Opens a modal per row; cannot batch. |
+| **Neutral** | `OpenPageActionDefinition` (OpenForm, OpenView) | Single-row navigation; neither enables nor vetoes. |
+
+The STRICT rule: AUTO=true when the table has ≥1 batchable row action AND zero input-needing row actions. A single input-needing action vetoes AUTO, because the user would see checkboxes + multi-select but one of the visible actions can only operate on one row at a time — misleading UX.
+
+All three `getIs*()` methods on `ActionDefinition` are derived from EClass identity (`this instanceof …`), so the category check is deterministic and null-safe.
+
+## Decision 2: Implicit toolbar bulk entries (Path A)
+
+When AUTO=true is granted only by the row-action path (no explicit BulkX), the generator emits one implicit toolbar entry per batchable row action.
+
+### Runtime contract mismatch and the `bulkFromRowAction` flag
+
+The existing `isBulk` toolbar path calls `actions[name](selectedRows.current)` — i.e. passes the whole selected-rows array and expects `{ result }` back. That's the contract for **explicit BulkX action functions** (e.g. `bulkDeleteAction(rows: T[])`).
+
+A **row action function** (e.g. `rowDeleteAction(row: T)`) takes a single row and returns `Promise<void>`. Reusing the same `name` for an implicit bulk toolbar entry therefore mismatches the runtime contract.
+
+The minimal-change fix: add a new flag `bulkFromRowAction?: boolean` to `ToolBarActionProps`, and one extra branch in the LazyTable/EagerTable click handler that fans out the per-row action across the selection:
+
+```typescript
+if (toolBarAction.isBulk) {
+  if (toolBarAction.bulkFromRowAction) {
+    for (const row of selectedRows.current) {
+      await actions[toolBarAction.name]!(row);
+    }
+    handleOnSelection([]);
+  } else {
+    const { result: bulkResult } = await actions[toolBarAction.name]!(selectedRows.current);
+    // … existing post-handling …
+  }
+}
+```
+
+### Implicit toolbar entry shape
+
+- `name`: same as the row action's name (e.g. `rowDeleteAction`) so it pulls the existing per-row action function.
+- `isBulk: true` — enables the toolbar bulk gesture.
+- `bulkFromRowAction: true` — selects the new fan-out branch.
+- `id`: derived from the row-action button's id with a stable suffix (`"<rowButton.id>::asBulk"`) so explicit and implicit toolbar entries can coexist without collision.
+- Label + icon: same as the row action.
+- `enabled:` condition: `selectionModel.ids.size > 0` (standard bulk pattern).
+
+The row-action icon in the actions column stays single-row-only with its existing `disabled if getSelectedRows().length > 0` guard. This preserves clean separation: toolbar = bulk, actions column = single row.
+
+### Error semantics for the fan-out
+
+The per-row loop is sequential. If `actions.rowDeleteAction(row)` throws for the 3rd row in a 5-row selection, the loop aborts and the first 2 succeeded mutations remain. This mirrors how a similar BulkCallOperation client-side fan-out would behave today; we explicitly do not introduce transaction rollback. Confirmation dialogs are not added by this change — the row action's own per-row confirmation is bypassed in the bulk path (otherwise the user would be prompted N times).
+
+### Deduplication
+
+If the modeler also declared an explicit BulkX (e.g. `BulkDelete`) on a table that has `RowDelete`, the implicit entry is suppressed. Rule: **explicit BulkX wins**; implicit entries only fire when no BulkX exists in `tableActionButtonGroup`.
+
+## New / changed Java helpers
+
+```java
+// UiTableHelper.java
+
+/**
+ * STRICT variant: true iff the table has at least one batchable row action
+ * and zero input-needing row actions. Neutral actions don't affect the result.
+ *
+ * Batchable    = RowDeleteActionDefinition, ParameterlessCallOperationActionDefinition
+ * Input-needing = InputFormCallOperationActionDefinition, InputSelectorCallOperationActionDefinition
+ */
+public static boolean tableHasAnyBatchableRowAction(Table table) {
+    if (table == null || table.getRowActionButtonGroup() == null) {
+        return false;
+    }
+    boolean hasBatchable = false;
+    for (Button button : table.getRowActionButtonGroup().getButtons()) {
+        ActionDefinition ad = button.getActionDefinition();
+        if (ad == null) continue;
+        // Veto check
+        if (ad.getIsInputFormCallOperationAction() || ad.getIsInputSelectorCallOperationAction()) {
+            return false;
+        }
+        // Batchable check
+        if (ad.getIsRowDeleteAction() || ad.getIsParameterlessCallOperationAction()) {
+            hasBatchable = true;
+        }
+    }
+    return hasBatchable;
+}
+```
+
+`checkboxSelectionForOwnPage` and `multiSelectAllowedForOwnPage` change from:
+
+```java
+if (cb == CheckboxSelection.AUTO) {
+    return tableHasAnyBulkAction(table);
+}
+```
+
+to:
+
+```java
+if (cb == CheckboxSelection.AUTO) {
+    return tableHasAnyBulkAction(table) || tableHasAnyBatchableRowAction(table);
+}
+```
+
+## Template changes
+
+### `containers/components/table/index.tsx.hbs`
+
+In the `toolBarActions` array builder (currently only reads `tableActionButtonGroup`), add a block that generates implicit bulk toolbar entries from batchable row actions when the table has no BulkX and AUTO was granted by the row-action path.
+
+Template-level condition:
+
+```handlebars
+{{# if (tableHasAnyBatchableRowAction table) }}
+  {{# unless (tableHasAnyBulkAction table) }}
+    {{# each table.rowActionButtonGroup.buttons as |button| }}
+      {{# if (isRowActionBatchable button.actionDefinition) }}
+        // emit implicit toolbar entry with isBulk: true
+      {{/ if }}
+    {{/ each }}
+  {{/ unless }}
+{{/ if }}
+```
+
+A new helper `isRowActionBatchable(ActionDefinition)` returns true for `RowDelete` and `ParameterlessCallOperation` action definitions.
+
+## Risk inventory
+
+- **Snapshot churn**: zero on existing models (no current itest model sets `checkboxSelection=AUTO` on a table without BulkX). Only the new fixture produces a diff.
+- **Client-side fan-out limitations**: the implicit toolbar entry calls the per-row REST endpoint N times. Errors are not atomic. The existing BulkX path has the same limitation for `BulkCallOperation` (also client-side fan-out in the current templates). Consistent behavior.
+- **Deduplication correctness**: the "explicit BulkX wins" rule prevents double-toolbar-entries. If the modeler has both `BulkDelete` and `RowDelete`, only the `BulkDelete` renders as a bulk toolbar button.

--- a/openspec/changes/jng-6399-followup-auto-from-batchable-row-actions/proposal.md
+++ b/openspec/changes/jng-6399-followup-auto-from-batchable-row-actions/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+JNG-6399 introduced `checkboxSelection=AUTO`, which turns on the checkbox column only when the table has at least one BulkX toolbar button (`BulkDelete`, `BulkRemove`, `BulkCallOperation`). A modeler who picks AUTO on a table with only row-level actions (no BulkX) gets `AUTO → false` — even when the table has row actions that are semantically batchable (e.g. `RowDelete` or `ParameterlessCallOperation`). The modeler expected "the generator figures it out," but it doesn't.
+
+## What Changes
+
+### AUTO predicate extended to consider row-action eligibility
+
+`multiSelectAllowedForOwnPage(table)` returns `true` under AUTO when **either**:
+
+1. The table has at least one BulkX toolbar button (existing rule, unchanged), **or**
+2. The table has at least one **batchable** row action AND **no** input-needing row action (STRICT veto rule).
+
+Action categories (closed list):
+
+| Category | Action definitions | Effect on AUTO |
+|---|---|---|
+| **Batchable** | `RowDeleteActionDefinition`, `ParameterlessCallOperationActionDefinition` | Enables AUTO=true |
+| **Input-needing (veto)** | `InputFormCallOperationActionDefinition`, `InputSelectorCallOperationActionDefinition` | VETOES AUTO=true |
+| **Neutral** | `OpenPageActionDefinition` | No effect |
+
+A single input-needing row action vetoes AUTO, even if batchable actions also exist.
+
+### Implicit toolbar bulk entries for batchable row actions
+
+When AUTO=true is granted **only** by the batchable-row-action rule (no explicit BulkX toolbar button), the generator emits one implicit toolbar entry per batchable row action. Each entry reuses the existing `isBulk: true` toolbar-action path and calls the per-row REST endpoint N times from the client. The row-action icon in the actions column stays single-row-only. Toolbar = bulk, actions column = single row.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `data-tables`: The "Row Selection" AUTO rule is extended so the inference considers row-action eligibility, and the generated app gains implicit bulk toolbar entries when AUTO was granted by the row-action path.
+
+## Impact
+
+- **Java helpers**: `UiTableHelper.java` — new helper `tableHasAnyBatchableRowAction(Table)`, updated `checkboxSelectionForOwnPage` / `multiSelectAllowedForOwnPage`.
+- **Templates**: `containers/components/table/index.tsx.hbs` — implicit toolbar entries for batchable row actions when no BulkX exists.
+- **Unit tests**: extended `CheckboxSelectionTest` for the STRICT veto matrix.
+- **itest snapshots**: zero diff for existing models (no current itest model sets `checkboxSelection=AUTO` on a table without BulkX). New fixture exercises the new code path.

--- a/openspec/changes/jng-6399-followup-auto-from-batchable-row-actions/specs/data-tables/spec.md
+++ b/openspec/changes/jng-6399-followup-auto-from-batchable-row-actions/specs/data-tables/spec.md
@@ -1,0 +1,70 @@
+## MODIFIED Requirements
+
+### Requirement: Row Selection — AUTO mode inference
+
+JNG-6399 defined AUTO as: "checkbox column renders iff `tableHasAnyBulkAction(table)` is true." This change extends the predicate.
+
+#### Extended AUTO inference rule
+
+When `checkboxSelection = AUTO`, the checkbox column SHALL render and `allowSelectMultiple` SHALL default to `true` if **either**:
+
+1. The table has at least one BulkX toolbar button (`BulkDeleteActionDefinition`, `BulkRemoveActionDefinition`, `BulkCallOperationActionDefinition`), **or**
+2. The table satisfies the **STRICT row-action batchability** rule:
+   - The table's `rowActionButtonGroup` contains at least one **batchable** row action, AND
+   - The table's `rowActionButtonGroup` contains **zero** input-needing row actions.
+
+##### Row-action categories (closed list)
+
+| Category | Action definitions | Effect |
+|---|---|---|
+| **Batchable** | `RowDeleteActionDefinition`, `ParameterlessCallOperationActionDefinition` | Enables AUTO=true |
+| **Input-needing (veto)** | `InputFormCallOperationActionDefinition`, `InputSelectorCallOperationActionDefinition` | VETOES AUTO=true |
+| **Neutral** | `OpenPageActionDefinition` | No effect on AUTO |
+
+A single input-needing row action SHALL veto AUTO, even if batchable row actions also exist.
+
+#### Implicit toolbar bulk entries
+
+When AUTO=true is granted **only** by the STRICT row-action rule (i.e. the table has no BulkX toolbar button), the generator SHALL emit one implicit toolbar entry per batchable row action in `rowActionButtonGroup`. Each implicit entry:
+
+- SHALL set `isBulk: true` and `bulkFromRowAction: true`.
+- SHALL use the same name (the per-row action name, e.g. `rowDeleteAction`), label, and icon as the corresponding row action.
+- SHALL use an id derived from the row-action button's id with a stable suffix (e.g. `"<rowButton.id>::asBulk"`).
+- SHALL NOT be emitted when an explicit BulkX toolbar button already exists on the table. Explicit BulkX wins.
+
+The runtime SHALL, on a toolbar bulk click where `bulkFromRowAction` is true, iterate the selected rows sequentially and invoke the per-row action for each, then clear the selection. Errors abort the loop.
+
+The row-action icon in the actions column SHALL remain single-row-only (no change to existing `disabled` guard).
+
+#### Scenario: AUTO on a table with RowDelete only (no BulkX)
+
+- **GIVEN** a `Table` with `checkboxSelection = AUTO`
+- **AND** the table has a `RowDelete` row action in `rowActionButtonGroup`
+- **AND** the table has no BulkX toolbar button in `tableActionButtonGroup`
+- **AND** the table has no input-needing row actions
+- **WHEN** the React app loads that page
+- **THEN** the checkbox column renders and `allowSelectMultiple` is `true`
+- **AND** an implicit bulk toolbar entry for the row-delete action renders with `isBulk: true`, `bulkFromRowAction: true`, and `enabled: selectionModel.ids.size > 0`
+
+#### Scenario: AUTO vetoed by InputFormCallOperation row action
+
+- **GIVEN** a `Table` with `checkboxSelection = AUTO`
+- **AND** the table has both a `RowDelete` row action and an `InputFormCallOperation` row action
+- **AND** the table has no BulkX toolbar button
+- **WHEN** the React app loads that page
+- **THEN** the checkbox column does NOT render (`AUTO → false`)
+- **AND** no implicit toolbar entry is generated
+
+#### Scenario: AUTO on a table with ParameterlessCallOperation only
+
+- **GIVEN** a `Table` with `checkboxSelection = AUTO`
+- **AND** the table has a `ParameterlessCallOperation` row action
+- **AND** the table has no BulkX and no input-needing row actions
+- **THEN** the checkbox column renders and an implicit bulk toolbar entry is generated
+
+#### Scenario: Explicit BulkX suppresses implicit entries
+
+- **GIVEN** a `Table` with `checkboxSelection = AUTO`
+- **AND** the table has both a `BulkDelete` toolbar button and a `RowDelete` row action
+- **THEN** the checkbox column renders (existing BulkX rule)
+- **AND** no implicit toolbar entry is generated for the `RowDelete` (explicit BulkX wins)

--- a/openspec/changes/jng-6399-followup-auto-from-batchable-row-actions/tasks.md
+++ b/openspec/changes/jng-6399-followup-auto-from-batchable-row-actions/tasks.md
@@ -1,0 +1,44 @@
+## 1. Java helpers (`UiTableHelper.java`)
+
+- [x] 1.1 Add `isRowActionBatchable(ActionDefinition ad)` — returns true iff `ad.getIsRowDeleteAction() || ad.getIsParameterlessCallOperationAction()`.
+- [x] 1.2 Add `tableHasAnyBatchableRowAction(Table table)` — STRICT variant: iterates `rowActionButtonGroup.buttons`, returns `false` immediately on any input-needing action, returns `true` only if ≥1 batchable found and 0 input-needing found. Null-safe on table, button group, and action definition.
+- [x] 1.3 Update `checkboxSelectionForOwnPage` AUTO branch: `return tableHasAnyBulkAction(table) || tableHasAnyBatchableRowAction(table);`
+- [x] 1.4 Update `multiSelectAllowedForOwnPage` (mirrors `checkboxSelectionForOwnPage` — same change).
+
+## 2. Template — implicit toolbar bulk entries
+
+- [x] 2.1 In `containers/components/table/index.tsx.hbs`, in the `toolBarActions` array builder: after the existing explicit toolbar entries from `tableActionButtonGroup`, add a block gated by `{{# if (tableHasAnyBatchableRowAction table) }}{{# unless (tableHasAnyBulkAction table) }}` that iterates `rowActionButtonGroup.buttons` and emits an implicit toolbar entry for each batchable row action. Each entry reuses the row action's name, label, icon, and sets `isBulk: true`, `bulkFromRowAction: true`, `enabled: selectionModel.ids.size > 0`, and an id of the form `"<rowButton.id>::asBulk"`.
+- [x] 2.2 In `utilities/table.ts.hbs`, add `bulkFromRowAction?: boolean` to the `ToolBarActionProps<T>` interface.
+- [x] 2.3 In `components/table/LazyTable.tsx.hbs` and `components/table/EagerTable.tsx.hbs`, inside the existing `if (toolBarAction.isBulk)` block, branch on `bulkFromRowAction`: when true, iterate `selectedRows.current` sequentially and call `actions[toolBarAction.name]!(row)` for each, then call `handleOnSelection([])` (LazyTable) / `handleOnSelection(createEmptySelectionModel())` (EagerTable).
+
+## 3. Unit tests
+
+- [x] 3.1 Add tests for `tableHasAnyBatchableRowAction`:
+      - `RowDelete` only → true
+      - `ParameterlessCallOperation` only → true
+      - Both batchable → true
+      - `RowDelete` + `InputFormCallOperation` → false (veto)
+      - `RowDelete` + `InputSelectorCallOperation` → false (veto)
+      - `InputFormCallOperation` only → false
+      - `OpenPage` only → false (neutral, no batchable)
+      - `RowDelete` + `OpenPage` → true (neutral doesn't veto)
+      - Empty button group → false
+      - Null table → false
+      - Null button group → false
+- [x] 3.2 Add tests for `checkboxSelectionForOwnPage` AUTO + row-action matrix:
+      - AUTO + bulk-only → true (existing rule)
+      - AUTO + batchable-row-only → true (new rule)
+      - AUTO + batchable-row + input-needing-row → false (veto)
+      - AUTO + no-bulk + no-row-actions → false
+
+## 4. Test fixture
+
+- [~] 4.1 **REVERTED**: The OperationParametersTest fixture edits (FlowerInfo → AUTO, BulkX removal) were tried in a local working tree and successfully demonstrated the new code path. They were then reverted to `origin/develop` to keep the itest model in sync with the live tatami-tests backend, because end-to-end frontend manual verification requires the upstream-deployed services and a fixture mismatch would break unrelated table loads (e.g. `~list` calls). The new code path is therefore covered by **unit tests only** (47 tests in `CheckboxSelectionTest`, including 20 new tests for the STRICT row-action matrix and the AUTO-from-row-action inference).
+- [x] 4.2 Verified manually before the revert: `containers/FlowerInfo/Table/components/FlowerInfoTableTableComponent/index.tsx` showed `allowSelectMultiple = true`, `checkboxSelection={isSelector ? true : true}`, and the implicit bulk toolbar entry `{ name: 'rowDeleteAction', id: '...::asBulk', isBulk: true, bulkFromRowAction: true, enabled: selectionModel.ids.size > 0 }`. Runtime branch is present in `components/table/LazyTable.tsx` and `EagerTable.tsx` regardless of fixture state (template-level code, always emitted).
+- [x] 4.3 No curated snapshot directory exists for OperationParametersTest; zero snapshot churn. After revert, regenerated FlowerInfo component contains no `bulkFromRowAction` / `::asBulk` entries (confirms suppression when explicit BulkX is present).
+
+## 5. Build verification
+
+- [x] 5.1 `mvn clean install` in `judo-ui-react`: 47 tests pass (was 27, added 20 new tests for the STRICT row-action matrix).
+- [x] 5.2 `mvn clean install` in `OperationParametersTest/operation_parameters_test__actor` (with `-DskipPrepareNodeJS`): BUILD SUCCESS.
+- [x] 5.3 Diff-checker: green (no curated snapshots in OperationParametersTest).

--- a/openspec/specs/data-tables/spec.md
+++ b/openspec/specs/data-tables/spec.md
@@ -131,14 +131,74 @@ The generator SHALL produce pagination controls for tables.
 
 ### Requirement: Row Selection
 
-The generator SHALL produce row selection functionality on tables.
+The generator SHALL honor `Table.checkboxSelection` faithfully when the table renders on its own page (own-page context), and SHALL exempt selector-mode rendering from that value.
 
-`checkboxSelection = ENABLED` SHALL show a checkbox column. `checkboxSelection = DISABLED` SHALL hide checkboxes. `checkboxSelection = AUTO` SHALL show checkboxes only when bulk actions exist. `allowSelectMultiple = true` SHALL enable multi-row selection. Selected rows SHALL be available to bulk actions.
+**Own-page context** is any rendering where the table is the page's primary content (access table page, view page, table embedded in a regular form). It is identified at runtime by `isSelector === false`.
 
-#### Scenario: Multi-row selection with checkboxes
+**Selector-mode context** is any rendering where the table is opened as an Add / Set / Operation-Input selector dialog. It is identified at runtime by `isSelector === true`.
 
-- **WHEN** a table has `checkboxSelection = ENABLED` and `allowSelectMultiple = true`
-- **THEN** a checkbox column is shown and multiple rows can be selected
+#### Own-page context rules
+
+The three enum values have distinct, non-overlapping meanings:
+
+`checkboxSelection = ENABLED` (and the ecore-default `null`) SHALL render the checkbox column and default `allowSelectMultiple` to `true`. No inference, no exceptions — the column appears even on tables with zero bulk operations. Bulk toolbar buttons SHALL appear when present in the model.
+
+`checkboxSelection = DISABLED` SHALL:
+
+- Hide the checkbox column on the generated MUI DataGrid.
+- Set the default `allowSelectMultiple` prop to `false` so Shift-click / Ctrl-click do not produce multi-row selections.
+- Hide any bulk toolbar buttons (`isBulk: true` toolbar entries) so the toolbar reflects that bulk actions are unreachable in this layout.
+
+`checkboxSelection = AUTO` SHALL render the checkbox column and allow multi-select if and only if the table has at least one bulk action. A "bulk action" is a button on `tableActionButtonGroup` whose action definition is one of `BulkDeleteActionDefinition`, `BulkRemoveActionDefinition`, or `BulkCallOperationActionDefinition`. The list is closed. When no such button exists, AUTO behaves identically to `DISABLED` (no column, no multi-select). When at least one exists, AUTO behaves identically to `ENABLED`.
+
+#### Selector-mode context rules
+
+Selector-mode rendering SHALL ignore the source table's `checkboxSelection` value. The checkbox column SHALL always render, and `allowSelectMultiple` SHALL be derived from the page-level `allowSelectMultipleForPage` helper (which inspects whether the parent page has an Add action wired into a container button group).
+
+Rationale: a selector dialog's purpose is to pick rows. The modeler's `DISABLED` describes the data display preference, not the picker contract. Form scenarios such as "open Galaxy as a selector to add multiple to a form" remain unaffected.
+
+#### Card and Tag representations
+
+For `representationComponent = CARD` and `representationComponent = TAG`, the `allowSelectMultiple` rules above apply identically (DISABLED ⇒ no multi, ENABLED/AUTO ⇒ multi). There is no checkbox column to hide in these representations; the gate is purely about whether row click contributes to the selection set.
+
+#### Scenario: DISABLED on a table's own page
+
+- **GIVEN** a `Table` with `checkboxSelection = DISABLED`
+- **AND** the table is rendered on a page where `isSelector = false`
+- **WHEN** the React app loads that page
+- **THEN** the generated DataGrid has `checkboxSelection={false}`
+- **AND** `allowSelectMultiple` resolves to `false`
+- **AND** any bulk toolbar buttons render with `enabled: () => false` (i.e. are hidden by `tableButtonVisibilityConditions`)
+
+#### Scenario: DISABLED on a table used as a selector
+
+- **GIVEN** the same `Table` with `checkboxSelection = DISABLED`
+- **AND** an Add action elsewhere opens this table as a selector dialog
+- **WHEN** the user opens that selector dialog
+- **THEN** the embedded DataGrid renders the checkbox column
+- **AND** `allowSelectMultiple` is derived from `allowSelectMultipleForPage(page)` — typically `true` when the parent Add action is wired through
+
+#### Scenario: ENABLED is the default and produces the previous behavior
+
+- **GIVEN** a `Table` whose `checkboxSelection` attribute is not set in the model (EMF ecore default `ENABLED`)
+- **THEN** the generated component behaves exactly as in versions prior to this change: checkbox column visible, multi-select on, bulk buttons visible
+
+#### Scenario: AUTO with at least one bulk action
+
+- **GIVEN** a `Table` with `checkboxSelection = AUTO`
+- **AND** the table's `tableActionButtonGroup` contains at least one BulkDelete, BulkRemove, or BulkCallOperation button
+- **THEN** the generated component behaves identically to `checkboxSelection = ENABLED` (column visible, multi-select on, bulk buttons rendered)
+
+#### Scenario: AUTO without any bulk action
+
+- **GIVEN** a `Table` with `checkboxSelection = AUTO`
+- **AND** the table's `tableActionButtonGroup` contains no BulkDelete, BulkRemove, or BulkCallOperation button
+- **THEN** the generated component behaves identically to `checkboxSelection = DISABLED` (column hidden, multi-select off)
+- **AND** the selector-mode override still applies: opening this table as a selector still renders the checkbox column
+
+**Key Helpers**: `UiTableHelper.tableHasAnyBulkAction()`, `UiTableHelper.checkboxSelectionForOwnPage()`, `UiTableHelper.multiSelectAllowedForOwnPage()`, `UiPageHelper.allowSelectMultipleForPage()`, `UiWidgetHelper.tableButtonVisibilityConditions()`
+
+**Template positions**: `containers/components/table/index.tsx.hbs` (the `checkboxSelection={...}` inline expression and the `allowSelectMultiple` destructured default), `containers/components/cards/index.tsx.hbs`, `containers/components/tag/index.tsx.hbs`
 
 ---
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-6399" title="JNG-6399" target="_blank"><img alt="Task" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />JNG-6399</a>  Remove bulk-action checkboxes from tables without bulk operations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## JIRA
[JNG-6399](https://blackbelttechnology.atlassian.net/browse/JNG-6399)

## Summary
Implements faithful honoring of `Table.checkboxSelection` in the generator:

- **ENABLED** (incl. ecore-default `null`): checkbox column visible, `allowSelectMultiple` defaults to `true`, bulk toolbar buttons rendered when modeled.
- **DISABLED**: checkbox column hidden, `allowSelectMultiple = false`, `isBulk` toolbar entries hidden via `tableButtonVisibilityConditions`.
- **AUTO**: checkbox column + multi-select if and only if the table has at least one button from the closed bulk-action list (`BulkDeleteActionDefinition`, `BulkRemoveActionDefinition`, `BulkCallOperationActionDefinition`). Otherwise behaves like DISABLED.
- **Selector-mode override**: when the table opens as an Add/Set/Operation-Input selector dialog (`isSelector === true`), the source `checkboxSelection` is ignored — checkbox column always renders and `allowSelectMultiple` is derived from `allowSelectMultipleForPage`.
- Same multi-select rules apply for `CARD` and `TAG` representations (no column to hide, only the multi-select gate).

## Why a re-applied commit?
The previous direct-push of this work to `develop` (`0208998a`) bypassed the PR workflow. It was reverted on `develop` (`563d6ab2`) and re-applied on this feature branch (`369918c4`) so the change can land via PR review as required.

## Key changes
- `UiTableHelper`: `tableHasAnyBulkAction`, `checkboxSelectionForOwnPage`, `multiSelectAllowedForOwnPage`
- `UiPageHelper.allowSelectMultipleForPage` (selector-mode multi gate)
- `UiWidgetHelper.tableButtonVisibilityConditions` (hides `isBulk` toolbar entries when checkbox col is hidden)
- Templates: `containers/components/table/index.tsx.hbs`, `cards/index.tsx.hbs`, `tag/index.tsx.hbs`, `components/table/EagerTable.tsx.hbs`, `LazyTable.tsx.hbs`, `utilities/table.ts.hbs`
- Unit test: `CheckboxSelectionTest` (27 cases)
- Spec sync: `openspec/specs/data-tables/spec.md` — Row Selection requirement rewritten with own-page vs selector-mode contexts and 5 scenarios
- OpenSpec change archived: `openspec/changes/archive/2026-05-15-JNG-6399-honor-checkbox-selection-mode/`

## Verification
- `mvn clean install -pl judo-ui-react -am`: 27/27 unit tests green
- `mvn clean install -pl judo-ui-react-itest/RelationTest/relation_test__actor -DskipPrepareNodeJS`: BUILD SUCCESS (generator + snapshot-checker + Vite production build)
- Only intentional snapshot diff: `allowSelectMultiple = true,` destructure default in tag-representation tables (task §3.2)

## Known follow-up
- CI build of this branch reported snapshot diffs on `ActionGroupTest` (Matter Table) and `ActionGroupTestPro` (Galaxy Table). These are the intended template-driven diffs from §3.1 / §3.2 and need a snapshot refresh in a follow-up commit on this branch before merge.
- Optional out-of-scope ticket noted in tasks 10.2: file a separate ticket against `judo-meta-jsl` for a JSL DSL keyword exposing `checkboxSelection`.

[JNG-6399]: https://blackbelt.atlassian.net/browse/JNG-6399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ